### PR TITLE
fix: sync-ebay-db に contents:write 権限を追加

### DIFF
--- a/.github/workflows/sync-ebay-db.yml
+++ b/.github/workflows/sync-ebay-db.yml
@@ -9,6 +9,8 @@ jobs:
   sync-ebay-db:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    permissions:
+      contents: write
 
     env:
       OUTPUT_DIR: ${{ github.workspace }}/ebay-db/output


### PR DESCRIPTION
git push 403エラー対応。GITHUB_TOKEN に contents:write を付与。

🤖 Generated with [Claude Code](https://claude.com/claude-code)