### PR TITLE
fix: Step1 Python stdout unbuffered でログ即時表示

### DIFF
--- a/.github/workflows/sync-ebay-db.yml
+++ b/.github/workflows/sync-ebay-db.yml
@@ -37,7 +37,8 @@ jobs:
           EBAY_CLIENT_ID:     ${{ secrets.EBAY_CLIENT_ID }}
           EBAY_CLIENT_SECRET: ${{ secrets.EBAY_CLIENT_SECRET }}
           OUTPUT_DIR:         ${{ env.OUTPUT_DIR }}
-        run: python ebay-db/scripts/fetch_category_master.py
+          PYTHONUNBUFFERED:   '1'
+        run: python -u ebay-db/scripts/fetch_category_master.py
 
       # ─── Step2: eBay コンディション取得 ───────────────────
       - name: Step2 - Fetch item condition policies


### PR DESCRIPTION
## Summary
- `PYTHONUNBUFFERED=1` と `python -u` を追加し、Step1のPythonログがバッファリングで表示されない問題を修正
- これによりStep1が実際に何をしているか（どのマーケットで止まっているか等）がリアルタイムで確認できる

## Test plan
- [ ] sync-ebay-db.yml を手動dispatch → Step1のログにeBay APIの取得状況が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)