### PR TITLE
feat: Step1をマーケット別stepに分割

### DIFF
--- a/.github/workflows/sync-ebay-db.yml
+++ b/.github/workflows/sync-ebay-db.yml
@@ -14,6 +14,7 @@ jobs:
 
     env:
       OUTPUT_DIR: ${{ github.workspace }}/ebay-db/output
+      PYTHONUNBUFFERED: '1'
 
     steps:
       - name: Checkout repository
@@ -31,35 +32,56 @@ jobs:
       - name: Install dependencies
         run: pip install -r ebay-db/scripts/requirements.txt
 
-      # ─── Step1: eBay カテゴリスペック取得 ─────────────────
-      - name: Step1 - Fetch category aspects (fetchItemAspects)
+      # ─── Step1: eBay カテゴリスペック取得（マーケット別）──
+      - name: Step1a - Fetch EBAY_US
         env:
           EBAY_CLIENT_ID:     ${{ secrets.EBAY_CLIENT_ID }}
           EBAY_CLIENT_SECRET: ${{ secrets.EBAY_CLIENT_SECRET }}
-          OUTPUT_DIR:         ${{ env.OUTPUT_DIR }}
-          PYTHONUNBUFFERED:   '1'
-        run: python -u ebay-db/scripts/fetch_category_master.py
+        run: python -u ebay-db/scripts/fetch_category_master.py fetch EBAY_US
+
+      - name: Step1b - Fetch EBAY_GB
+        env:
+          EBAY_CLIENT_ID:     ${{ secrets.EBAY_CLIENT_ID }}
+          EBAY_CLIENT_SECRET: ${{ secrets.EBAY_CLIENT_SECRET }}
+        run: python -u ebay-db/scripts/fetch_category_master.py fetch EBAY_GB
+
+      - name: Step1c - Fetch EBAY_DE
+        env:
+          EBAY_CLIENT_ID:     ${{ secrets.EBAY_CLIENT_ID }}
+          EBAY_CLIENT_SECRET: ${{ secrets.EBAY_CLIENT_SECRET }}
+        run: python -u ebay-db/scripts/fetch_category_master.py fetch EBAY_DE
+
+      - name: Step1d - Fetch EBAY_AU
+        env:
+          EBAY_CLIENT_ID:     ${{ secrets.EBAY_CLIENT_ID }}
+          EBAY_CLIENT_SECRET: ${{ secrets.EBAY_CLIENT_SECRET }}
+        run: python -u ebay-db/scripts/fetch_category_master.py fetch EBAY_AU
+
+      - name: Step1e - Fetch EBAY_JP
+        env:
+          EBAY_CLIENT_ID:     ${{ secrets.EBAY_CLIENT_ID }}
+          EBAY_CLIENT_SECRET: ${{ secrets.EBAY_CLIENT_SECRET }}
+        run: python -u ebay-db/scripts/fetch_category_master.py fetch EBAY_JP
+
+      - name: Step1f - Combine all marketplace data
+        run: python -u ebay-db/scripts/fetch_category_master.py combine
 
       # ─── Step2: eBay コンディション取得 ───────────────────
       - name: Step2 - Fetch item condition policies
         env:
           EBAY_CLIENT_ID:     ${{ secrets.EBAY_CLIENT_ID }}
           EBAY_CLIENT_SECRET: ${{ secrets.EBAY_CLIENT_SECRET }}
-          OUTPUT_DIR:         ${{ env.OUTPUT_DIR }}
-        run: python ebay-db/scripts/fetch_conditions.py
+        run: python -u ebay-db/scripts/fetch_conditions.py
 
       # ─── Step3: FVFレート抽出（Gemini） ───────────────────
       - name: Step3 - Extract FVF rates via Gemini
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          OUTPUT_DIR:     ${{ env.OUTPUT_DIR }}
-        run: python ebay-db/scripts/extract_fvf.py
+        run: python -u ebay-db/scripts/extract_fvf.py
 
       # ─── Step4: CSV 生成 ───────────────────────────────────
       - name: Step4 - Generate CSV files
-        env:
-          OUTPUT_DIR: ${{ env.OUTPUT_DIR }}
-        run: python ebay-db/scripts/generate_csv.py
+        run: python -u ebay-db/scripts/generate_csv.py
 
       # ─── Step5: CSV をリポジトリにコミット ────────────────
       - name: Step5 - Commit CSVs to repository

--- a/ebay-db/scripts/fetch_category_master.py
+++ b/ebay-db/scripts/fetch_category_master.py
@@ -1,13 +1,16 @@
 """
 fetch_category_master.py
 eBay Taxonomy API の fetchItemAspects で全リーフカテゴリのスペックを取得
-出力: category_raw.json
+出力: category_raw_{marketplace_id}.json (--marketplace 指定時)
+      category_raw.json (--combine 時に全ファイルを結合)
 """
 
 import os
 import json
 import gzip
 import time
+import glob
+import argparse
 import requests
 
 MAX_RETRIES = 3
@@ -121,33 +124,99 @@ def build_category_rows(aspects: list[dict], marketplace_id: str, category_tree_
     return rows
 
 
-def main():
-    print("=== fetch_category_master.py 開始 ===")
+def cmd_fetch(marketplace_id: str):
+    """1マーケットのみ取得して category_raw_{marketplace_id}.json に保存"""
+    target = next((mp for mp in MARKETPLACES if mp["marketplace_id"] == marketplace_id), None)
+    if not target:
+        print(f"❌ 不明なマーケットプレイス: {marketplace_id}")
+        raise SystemExit(1)
+
+    print(f"=== fetch_category_master.py [{marketplace_id}] 開始 ===")
     token = get_access_token()
+
+    print(f"取得中: {target['marketplace_id']} (tree_id={target['category_tree_id']})")
+    aspects = fetch_aspects_for_marketplace(token, target["category_tree_id"])
+    rows = build_category_rows(aspects, target["marketplace_id"], target["category_tree_id"])
+    print(f"  → {len(rows)} カテゴリ取得")
+
+    out_dir = os.environ.get("OUTPUT_DIR", ".")
+    output_path = f"{out_dir}/category_raw_{marketplace_id}.json"
+    with open(output_path, "w", encoding="utf-8") as f:
+        json.dump(rows, f, ensure_ascii=False, indent=2)
+
+    print(f"=== 完了: {len(rows)} 行 → {output_path} ===")
+
+    if len(rows) == 0:
+        print(f"❌ エラー: データが0件です")
+        raise SystemExit(1)
+
+
+def cmd_combine():
+    """全マーケットの category_raw_*.json を結合して category_raw.json に出力"""
+    out_dir = os.environ.get("OUTPUT_DIR", ".")
+    pattern = f"{out_dir}/category_raw_EBAY_*.json"
+    files = sorted(glob.glob(pattern))
+
+    if not files:
+        print(f"❌ エラー: {pattern} にファイルが見つかりません")
+        raise SystemExit(1)
+
     all_rows = []
-    failed_markets = []
+    for path in files:
+        with open(path, encoding="utf-8") as f:
+            rows = json.load(f)
+        print(f"  {os.path.basename(path)}: {len(rows)} 行")
+        all_rows.extend(rows)
 
-    for mp in MARKETPLACES:
-        print(f"取得中: {mp['marketplace_id']} (tree_id={mp['category_tree_id']})")
-        try:
-            aspects = fetch_aspects_for_marketplace(token, mp["category_tree_id"])
-            rows = build_category_rows(aspects, mp["marketplace_id"], mp["category_tree_id"])
-            all_rows.extend(rows)
-            print(f"  → {len(rows)} カテゴリ取得")
-        except Exception as e:
-            failed_markets.append(mp["marketplace_id"])
-            print(f"  ⚠️ {mp['marketplace_id']} 取得失敗: {e}")
-
-    output_path = os.environ.get("OUTPUT_DIR", ".") + "/category_raw.json"
+    output_path = f"{out_dir}/category_raw.json"
     with open(output_path, "w", encoding="utf-8") as f:
         json.dump(all_rows, f, ensure_ascii=False, indent=2)
 
-    print(f"=== 完了: {len(all_rows)} 行 → {output_path} ===")
+    print(f"=== combine 完了: 合計 {len(all_rows)} 行 → {output_path} ===")
 
-    # 全マーケットプレイス失敗 or データ0件なら異常終了
-    if len(all_rows) == 0:
-        print(f"❌ エラー: データが0件です。失敗: {failed_markets}")
-        raise SystemExit(1)
+
+def main():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+
+    fetch_parser = subparsers.add_parser("fetch", help="1マーケット取得")
+    fetch_parser.add_argument("marketplace_id", help="例: EBAY_US")
+
+    subparsers.add_parser("combine", help="全マーケットファイルを結合")
+
+    args = parser.parse_args()
+
+    if args.command == "fetch":
+        cmd_fetch(args.marketplace_id)
+    elif args.command == "combine":
+        cmd_combine()
+    else:
+        # 後方互換: 引数なしで全マーケット順次取得
+        print("=== fetch_category_master.py 開始 (全マーケット) ===")
+        token = get_access_token()
+        all_rows = []
+        failed_markets = []
+
+        for mp in MARKETPLACES:
+            print(f"取得中: {mp['marketplace_id']} (tree_id={mp['category_tree_id']})")
+            try:
+                aspects = fetch_aspects_for_marketplace(token, mp["category_tree_id"])
+                rows = build_category_rows(aspects, mp["marketplace_id"], mp["category_tree_id"])
+                all_rows.extend(rows)
+                print(f"  → {len(rows)} カテゴリ取得")
+            except Exception as e:
+                failed_markets.append(mp["marketplace_id"])
+                print(f"  ⚠️ {mp['marketplace_id']} 取得失敗: {e}")
+
+        output_path = os.environ.get("OUTPUT_DIR", ".") + "/category_raw.json"
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(all_rows, f, ensure_ascii=False, indent=2)
+
+        print(f"=== 完了: {len(all_rows)} 行 → {output_path} ===")
+
+        if len(all_rows) == 0:
+            print(f"❌ エラー: データが0件です。失敗: {failed_markets}")
+            raise SystemExit(1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `fetch_category_master.py` に `fetch <MARKETPLACE_ID>` / `combine` サブコマンドを追加
- ワークフローのStep1を5つの独立stepに分割（Step1a〜Step1e + Step1f combine）
- 各マーケット完了をstep単位でリアルタイム確認可能

🤖 Generated with [Claude Code](https://claude.com/claude-code)