### PR TITLE
fix: fetch_conditions エラー時もサンプル上限でbreak

### DIFF
--- a/ebay-db/scripts/fetch_conditions.py
+++ b/ebay-db/scripts/fetch_conditions.py
@@ -89,13 +89,15 @@ def cmd_fetch(marketplace_id: str):
 
     processed = 0
     errors = 0
+    attempts = 0  # 成否にかかわらず試行回数をカウント
 
     for row in rows:
-        if processed >= SAMPLE_PER_MARKET:
-            break  # サンプル上限に達したら早期終了
+        if attempts >= SAMPLE_PER_MARKET:
+            break  # 試行回数上限に達したら早期終了
 
         tree_id = row["category_tree_id"]
         cat_id = row["category_id"]
+        attempts += 1
 
         try:
             conditions = fetch_conditions_for_category(token, tree_id, cat_id)


### PR DESCRIPTION
## Summary
- エラー発生時 `processed` が増えず全15,000件をループするバグを修正
- `attempts`（成否不問）で `SAMPLE_PER_MARKET` 件後に必ず `break`

## 影響
- 修正前: エラー多発時に15,000件 × 0.1s sleep = 25分以上
- 修正後: 常に20件試行後に終了 = 最大40秒

🤖 Generated with [Claude Code](https://claude.com/claude-code)