### PR TITLE
feat: category_master に6つのアスペクト列を追加（required/recommended/optional/values/modes/multi）

### DIFF
--- a/ebay-db/scripts/fetch_category_master.py
+++ b/ebay-db/scripts/fetch_category_master.py
@@ -95,28 +95,54 @@ def build_category_rows(aspects: list[dict], marketplace_id: str, category_tree_
         cat_name = category.get("categoryName") or item.get("categoryName", "")
         aspect_list = item.get("aspects", [])
 
-        required, recommended, optional = [], [], []
+        required_names, recommended_names, optional_names = [], [], []
+        aspect_values: dict[str, list[str]] = {}
+        aspect_modes: dict[str, str] = {}
+        multi_value_names: list[str] = []
+
         for asp in aspect_list:
-            usage = asp.get("aspectConstraint", {}).get("aspectUsage", "OPTIONAL")
-            entry = {
-                "name": asp.get("localizedAspectName", ""),
-                "values": [v.get("localizedValue", "") for v in asp.get("aspectValues", [])[:50]],
-            }
-            if usage == "REQUIRED":
-                required.append(entry)
+            constraint    = asp.get("aspectConstraint", {})
+            is_required   = constraint.get("aspectRequired", False)
+            usage         = constraint.get("aspectUsage", "OPTIONAL")
+            mode          = constraint.get("aspectMode", "")
+            cardinality   = constraint.get("itemToAspectCardinality", "SINGLE")
+            name          = asp.get("localizedAspectName", "")
+            if not name:
+                continue
+
+            # SELECTION_ONLY の場合のみ値リストを格納（FREE_TEXT は空欄のまま）
+            if mode == "SELECTION_ONLY":
+                vals = [
+                    v.get("localizedValue", "")
+                    for v in asp.get("aspectValues", [])
+                    if v.get("localizedValue")
+                ][:50]
+                if vals:
+                    aspect_values[name] = vals
+
+            aspect_modes[name] = mode
+
+            if cardinality == "MULTI":
+                multi_value_names.append(name)
+
+            if is_required or usage == "REQUIRED":
+                required_names.append(name)
             elif usage == "RECOMMENDED":
-                recommended.append(entry)
+                recommended_names.append(name)
             else:
-                optional.append(entry)
+                optional_names.append(name)
 
         rows.append({
-            "marketplace_id": marketplace_id,
-            "category_tree_id": category_tree_id,
-            "category_id": cat_id,
-            "category_name": cat_name,
-            "required_specs_json": json.dumps(required, ensure_ascii=False),
-            "recommended_specs_json": json.dumps(recommended, ensure_ascii=False),
-            "optional_specs_json": json.dumps(optional, ensure_ascii=False),
+            "marketplace_id":           marketplace_id,
+            "category_tree_id":         category_tree_id,
+            "category_id":              cat_id,
+            "category_name":            cat_name,
+            "required_specs_json":      json.dumps(required_names,    ensure_ascii=False),
+            "recommended_specs_json":   json.dumps(recommended_names, ensure_ascii=False),
+            "optional_specs_json":      json.dumps(optional_names,    ensure_ascii=False),
+            "aspect_values_json":       json.dumps(aspect_values,     ensure_ascii=False),
+            "aspect_modes_json":        json.dumps(aspect_modes,      ensure_ascii=False),
+            "multi_value_aspects_json": json.dumps(multi_value_names, ensure_ascii=False),
             "conditions_json": "",      # fetch_conditions.py で補完
             "fvf_rate": "",             # extract_fvf.py で補完
             "last_synced": "",          # generate_csv.py で補完

--- a/ebay-db/scripts/generate_csv.py
+++ b/ebay-db/scripts/generate_csv.py
@@ -68,6 +68,8 @@ def generate_category_master(rows: list[dict], fvf_rates: dict) -> None:
     """
     fieldnames = [
         "marketplace_id", "category_tree_id", "category_id", "category_name",
+        "required_specs_json", "recommended_specs_json", "optional_specs_json",
+        "aspect_values_json", "aspect_modes_json", "multi_value_aspects_json",
         "conditions_json", "fvf_rate", "last_synced",
     ]
 
@@ -96,13 +98,19 @@ def generate_category_master(rows: list[dict], fvf_rates: dict) -> None:
                         break
 
                 writer.writerow({
-                    "marketplace_id":   mp,
-                    "category_tree_id": row.get("category_tree_id", ""),
-                    "category_id":      row.get("category_id", ""),
-                    "category_name":    cat_name,
-                    "conditions_json":  row.get("conditions_json", "[]"),
-                    "fvf_rate":         fvf_rate,
-                    "last_synced":      TODAY,
+                    "marketplace_id":           mp,
+                    "category_tree_id":         row.get("category_tree_id", ""),
+                    "category_id":              row.get("category_id", ""),
+                    "category_name":            cat_name,
+                    "required_specs_json":      row.get("required_specs_json",      "[]"),
+                    "recommended_specs_json":   row.get("recommended_specs_json",   "[]"),
+                    "optional_specs_json":      row.get("optional_specs_json",      "[]"),
+                    "aspect_values_json":       row.get("aspect_values_json",       "{}"),
+                    "aspect_modes_json":        row.get("aspect_modes_json",        "{}"),
+                    "multi_value_aspects_json": row.get("multi_value_aspects_json", "[]"),
+                    "conditions_json":          row.get("conditions_json",          "[]"),
+                    "fvf_rate":                 fvf_rate,
+                    "last_synced":              TODAY,
                 })
 
         print(f"  {output_path}: {len(mp_rows)} 行")


### PR DESCRIPTION
## Summary

`fetchItemAspects` レスポンスの `aspectConstraint` から以下6列を抽出して `category_master_EBAY_XX.csv` に追加。

| 列名 | ソースキー | 内容 |
|---|---|---|
| `required_specs_json` | `aspectRequired=true` or `aspectUsage="REQUIRED"` | 必須アスペクト名リスト |
| `recommended_specs_json` | `aspectUsage="RECOMMENDED"` | 推奨アスペクト名リスト |
| `optional_specs_json` | それ以外 | 任意アスペクト名リスト |
| `aspect_values_json` | `aspectMode="SELECTION_ONLY"` の `aspectValues[].localizedValue` | 選択肢マップ `{name: [values]}` |
| `aspect_modes_json` | `aspectConstraint.aspectMode` | 入力モードマップ `{name: mode}` |
| `multi_value_aspects_json` | `itemToAspectCardinality="MULTI"` | 複数選択可アスペクト名リスト |

`aspect_values_json` は `SELECTION_ONLY` のみ対象・上限50件（`FREE_TEXT` は値なし）

## Test plan

- [ ] CSV ヘッダーに6列が追加されていること
- [ ] `required_specs_json` に必須アスペクト名が入っていること
- [ ] `aspect_values_json` に `{"Brand": ["Apple", ...]}` 形式で値が入っていること
- [ ] `aspect_modes_json` に `{"MPN": "FREE_TEXT"}` 等が入っていること
- [ ] `multi_value_aspects_json` に複数選択可能なアスペクト名が含まれること

🤖 Generated with [Claude Code](https://claude.com/claude-code)