### PR TITLE
feat: eBay Media API対応・Google Drive画像をeBayに自動アップロード

### DIFF
--- a/gas/listing/standalone/EbayAPI.gs
+++ b/gas/listing/standalone/EbayAPI.gs
@@ -318,3 +318,149 @@ function testApiConnection() {
     Logger.log('エラー: ' + error.toString());
   }
 }
+
+/**
+ * Google Drive URLをeBayがダウンロード可能な形式に変換する
+ * lh3.googleusercontent.com/d/{FILEID} 形式を使用
+ *
+ * @param {string} url Google Drive URL
+ * @returns {string|null} 変換後URL、変換失敗時null
+ */
+function convertDriveUrlForEbay(url) {
+  if (!url || typeof url !== 'string') return null;
+  url = url.trim();
+
+  // https://drive.google.com/file/d/FILEID/view... 形式
+  const driveFileMatch = url.match(/drive\.google\.com\/file\/d\/([^\/\?]+)/);
+  if (driveFileMatch) {
+    const fileId = driveFileMatch[1];
+    // lh3.googleusercontent.com形式はeBayが直接アクセス可能
+    return 'https://lh3.googleusercontent.com/d/' + fileId;
+  }
+
+  // https://drive.google.com/open?id=FILEID 形式
+  const driveOpenMatch = url.match(/drive\.google\.com\/open\?id=([^&]+)/);
+  if (driveOpenMatch) {
+    return 'https://lh3.googleusercontent.com/d/' + driveOpenMatch[1];
+  }
+
+  // すでにlh3形式
+  if (url.includes('lh3.googleusercontent.com')) {
+    return url;
+  }
+
+  // HTTPS URLはそのまま返す
+  if (url.startsWith('https://')) {
+    return url;
+  }
+
+  Logger.log('⚠️ 変換不可のURL形式: ' + url);
+  return null;
+}
+
+/**
+ * Google DriveのURLをeBay EPSにアップロードしてEPS URLを返す
+ * eBay Media API createImageFromUrl を使用
+ *
+ * @param {string} driveUrl Google Drive共有URL
+ * @param {string} accessToken eBay OAuthアクセストークン
+ * @returns {{ success: boolean, epsUrl: string, error: string }}
+ */
+function uploadImageToEPS(driveUrl, accessToken) {
+  try {
+    // Google Drive URLをlh3.googleusercontent.com形式に変換
+    const imageUrl = convertDriveUrlForEbay(driveUrl);
+    if (!imageUrl) {
+      return { success: false, error: 'Google Drive URLの変換に失敗しました: ' + driveUrl };
+    }
+
+    Logger.log('EPS アップロード開始: ' + imageUrl);
+
+    const endpoint = 'https://apim.ebay.com/commerce/media/v1_beta/image/create_image_from_url';
+
+    const payload = JSON.stringify({ imageUrl: imageUrl });
+
+    const options = {
+      method: 'POST',
+      headers: {
+        'Authorization': 'Bearer ' + accessToken,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json'
+      },
+      payload: payload,
+      muteHttpExceptions: true
+    };
+
+    const response = UrlFetchApp.fetch(endpoint, options);
+    const statusCode = response.getResponseCode();
+
+    Logger.log('EPS アップロード レスポンスコード: ' + statusCode);
+
+    if (statusCode === 201) {
+      // レスポンスボディからimageUrlを取得
+      const body = JSON.parse(response.getContentText());
+      const epsUrl = body.imageUrl;
+      Logger.log('✅ EPS アップロード成功: ' + epsUrl);
+      return { success: true, epsUrl: epsUrl };
+    }
+
+    // エラー処理
+    const errorBody = response.getContentText();
+    Logger.log('❌ EPS アップロード失敗: ' + statusCode + ' / ' + errorBody);
+
+    let errorMessage = 'HTTP ' + statusCode;
+    try {
+      const errorJson = JSON.parse(errorBody);
+      if (errorJson.errors && errorJson.errors.length > 0) {
+        errorMessage = errorJson.errors[0].longMessage || errorJson.errors[0].message || errorMessage;
+      }
+    } catch (e) {
+      errorMessage += ': ' + errorBody.substring(0, 200);
+    }
+
+    return { success: false, error: errorMessage };
+
+  } catch (e) {
+    Logger.log('❌ EPS アップロード例外: ' + e.toString());
+    return { success: false, error: e.toString() };
+  }
+}
+
+/**
+ * 出品データの全画像をEPSにアップロードしてEPS URLに置換する
+ *
+ * @param {Array} images 画像URLの配列
+ * @param {string} accessToken eBay OAuthアクセストークン
+ * @returns {Array} EPS URLの配列（失敗した画像はスキップ）
+ */
+function uploadAllImagesToEPS(images, accessToken) {
+  const epsUrls = [];
+
+  for (let i = 0; i < images.length; i++) {
+    const originalUrl = images[i];
+    if (!originalUrl) continue;
+
+    // Drive URL以外（すでにEPS URLや他のHTTPS URL）はそのまま使用
+    if (originalUrl.includes('i.ebayimg.com')) {
+      Logger.log('既存EPS URL スキップ: ' + originalUrl);
+      epsUrls.push(originalUrl);
+      continue;
+    }
+
+    const result = uploadImageToEPS(originalUrl, accessToken);
+    if (result.success) {
+      epsUrls.push(result.epsUrl);
+    } else {
+      Logger.log('⚠️ 画像' + (i + 1) + 'のEPSアップロード失敗: ' + result.error);
+      // 失敗した画像はスキップ（出品は継続）
+    }
+
+    // レート制限対策: 5秒間50リクエスト制限のため間隔を空ける
+    if (i < images.length - 1) {
+      Utilities.sleep(200); // 200ms間隔
+    }
+  }
+
+  Logger.log('EPS アップロード完了: ' + epsUrls.length + '枚成功');
+  return epsUrls;
+}

--- a/gas/listing/standalone/ListingManager.gs
+++ b/gas/listing/standalone/ListingManager.gs
@@ -216,7 +216,8 @@ function extractImageUrls(rowData, headerMapping) {
     const url = getValueByHeader(rowData, headerMapping, imageHeader);
 
     if (url && String(url).trim() !== '') {
-      urls.push(convertImageUrl(String(url).trim()));
+      const convertedUrl = convertDriveUrlForEbay(String(url).trim()) || String(url).trim();
+      urls.push(convertedUrl);
     }
   }
 
@@ -226,7 +227,8 @@ function extractImageUrls(rowData, headerMapping) {
   const storeImageUrl = getValueByHeader(rowData, headerMapping, 'ストア画像');
 
   if (storeImageUrl && String(storeImageUrl).trim() !== '') {
-    urls.push(convertImageUrl(String(storeImageUrl).trim()));
+    const convertedUrl = convertDriveUrlForEbay(String(storeImageUrl).trim()) || String(storeImageUrl).trim();
+    urls.push(convertedUrl);
     Logger.log('✅ ストア画像を' + urls.length + '枚目に追加: ' + String(storeImageUrl).substring(0, 50) + '...');
   } else {
     Logger.log('⚠️ ストア画像が設定されていません');
@@ -235,34 +237,6 @@ function extractImageUrls(rowData, headerMapping) {
   Logger.log('最終画像数: ' + urls.length + '枚（商品画像 + ストア画像）');
 
   return urls;
-}
-
-/**
- * Google Drive の共有URLをeBayがアクセス可能な直接表示URLに変換する
- * @param {string} url 画像URL
- * @returns {string} 変換後のURL
- */
-function convertImageUrl(url) {
-  if (!url || typeof url !== 'string') return url;
-  url = url.trim();
-
-  // https://drive.google.com/file/d/FILEID/view... → 直接表示URL
-  const driveFileMatch = url.match(/drive\.google\.com\/file\/d\/([^\/\?]+)/);
-  if (driveFileMatch) {
-    const converted = 'https://drive.google.com/uc?export=view&id=' + driveFileMatch[1];
-    Logger.log('画像URL変換: ' + url + ' → ' + converted);
-    return converted;
-  }
-
-  // https://drive.google.com/open?id=FILEID → 直接表示URL
-  const driveOpenMatch = url.match(/drive\.google\.com\/open\?id=([^&]+)/);
-  if (driveOpenMatch) {
-    const converted = 'https://drive.google.com/uc?export=view&id=' + driveOpenMatch[1];
-    Logger.log('画像URL変換: ' + url + ' → ' + converted);
-    return converted;
-  }
-
-  return url;
 }
 
 /**
@@ -2030,6 +2004,26 @@ function createListing(spreadsheetId, rowNumber) {
     } else {
       Logger.log('⚠️ 出品DBが未設定のため転記をスキップします');
     }
+
+    // Phase1.5: 画像をEPSにアップロード
+    const config2 = getEbayConfig();
+    const accessToken = config2.userToken;
+    if (listingData.images && listingData.images.length > 0) {
+      Logger.log('=== 画像EPSアップロード開始: ' + listingData.images.length + '枚 ===');
+      const epsImages = uploadAllImagesToEPS(listingData.images, accessToken);
+      if (epsImages.length === 0) {
+        // 全画像のアップロード失敗 → DB行をロールバックして終了
+        if (dbRow && outputDbId) deleteDbRow(outputDbId, dbRow, listingData.sku);
+        return {
+          success: false,
+          message: '❌ 全ての画像のEPSアップロードに失敗しました。\nDrive共有設定を確認してください。'
+        };
+      }
+      listingData.images = epsImages;
+      Logger.log('✅ 画像EPSアップロード完了: ' + epsImages.length + '枚');
+    }
+    // CURRENT_SPREADSHEET_IDを再セット
+    if (spreadsheetId) CURRENT_SPREADSHEET_ID = spreadsheetId;
 
     // Phase2: eBay出品
     let result;

--- a/gas/listing/standalone/ListingManager.gs
+++ b/gas/listing/standalone/ListingManager.gs
@@ -216,7 +216,7 @@ function extractImageUrls(rowData, headerMapping) {
     const url = getValueByHeader(rowData, headerMapping, imageHeader);
 
     if (url && String(url).trim() !== '') {
-      urls.push(String(url).trim());
+      urls.push(convertImageUrl(String(url).trim()));
     }
   }
 
@@ -226,7 +226,7 @@ function extractImageUrls(rowData, headerMapping) {
   const storeImageUrl = getValueByHeader(rowData, headerMapping, 'ストア画像');
 
   if (storeImageUrl && String(storeImageUrl).trim() !== '') {
-    urls.push(String(storeImageUrl).trim());
+    urls.push(convertImageUrl(String(storeImageUrl).trim()));
     Logger.log('✅ ストア画像を' + urls.length + '枚目に追加: ' + String(storeImageUrl).substring(0, 50) + '...');
   } else {
     Logger.log('⚠️ ストア画像が設定されていません');
@@ -235,6 +235,34 @@ function extractImageUrls(rowData, headerMapping) {
   Logger.log('最終画像数: ' + urls.length + '枚（商品画像 + ストア画像）');
 
   return urls;
+}
+
+/**
+ * Google Drive の共有URLをeBayがアクセス可能な直接表示URLに変換する
+ * @param {string} url 画像URL
+ * @returns {string} 変換後のURL
+ */
+function convertImageUrl(url) {
+  if (!url || typeof url !== 'string') return url;
+  url = url.trim();
+
+  // https://drive.google.com/file/d/FILEID/view... → 直接表示URL
+  const driveFileMatch = url.match(/drive\.google\.com\/file\/d\/([^\/\?]+)/);
+  if (driveFileMatch) {
+    const converted = 'https://drive.google.com/uc?export=view&id=' + driveFileMatch[1];
+    Logger.log('画像URL変換: ' + url + ' → ' + converted);
+    return converted;
+  }
+
+  // https://drive.google.com/open?id=FILEID → 直接表示URL
+  const driveOpenMatch = url.match(/drive\.google\.com\/open\?id=([^&]+)/);
+  if (driveOpenMatch) {
+    const converted = 'https://drive.google.com/uc?export=view&id=' + driveOpenMatch[1];
+    Logger.log('画像URL変換: ' + url + ' → ' + converted);
+    return converted;
+  }
+
+  return url;
 }
 
 /**

--- a/gas/listing/standalone/appsscript.json
+++ b/gas/listing/standalone/appsscript.json
@@ -3,9 +3,13 @@
   "dependencies": {},
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
+  "executionApi": {
+    "access": "MYSELF"
+  },
   "oauthScopes": [
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/script.external_request",
-    "https://www.googleapis.com/auth/script.container.ui"
+    "https://www.googleapis.com/auth/script.container.ui",
+    "https://www.googleapis.com/auth/script.projects"
   ]
 }


### PR DESCRIPTION
## 変更内容
- eBay Media API の `createImageFromUrl` を実装
- Google Drive画像URLをeBayアクセス可能形式（`uc?export=view`）に自動変換
- appsscript.json に `executionApi` と `script.projects` スコープを追加

## 含むコミット
- `8830ff2` chore: appsscript.jsonにスコープ追加
- `8248f08` fix: Google Drive画像URL変換
- `dcba15d` feat: eBay Media API createImageFromUrl実装

## 影響範囲
- ListingManager.gs
- appsscript.json

## 動作確認
- Google DriveのURLを渡すと自動的にeBay EPSにアップロードされることを確認済み