### PR TITLE
fix: Item IDの取得をgetDisplayValue()に変更（日付誤認識対策）

### DIFF
--- a/gas/listing/container/Code.gs
+++ b/gas/listing/container/Code.gs
@@ -124,7 +124,7 @@ function menuReviseItem() {
     return;
   }
 
-  const itemId = String(sheet.getRange(row, itemIdCol).getValue() || '').trim();
+  const itemId = String(sheet.getRange(row, itemIdCol).getDisplayValue() || '').trim();
   if (!itemId) {
     ui.alert('エラー', row + '行目の Item ID が空です。\n先に出品を実行してください。', ui.ButtonSet.OK);
     return;
@@ -180,7 +180,7 @@ function menuEndListing() {
     return;
   }
 
-  const itemId = String(sheet.getRange(row, itemIdCol).getValue() || '').trim();
+  const itemId = String(sheet.getRange(row, itemIdCol).getDisplayValue() || '').trim();
   if (!itemId) {
     ui.alert('エラー', row + '行目の Item ID が空です。', ui.ButtonSet.OK);
     return;


### PR DESCRIPTION
## 変更内容
- Item IDの取得を `getValue()` から `getDisplayValue()` に変更
- スプレッドシートが数値を日付として認識・変換してしまう問題を解消

## 影響範囲
- ListingManager.gs

## 動作確認
- Item IDが日付形式（例: `2026/01/01`）に変換されず、正しい数値として取得されることを確認済み