### PR TITLE
feat: 全機能統合リリース（34コミット）

### DIFF
--- a/gas/listing/container/Code.gs
+++ b/gas/listing/container/Code.gs
@@ -69,10 +69,36 @@ function menuCreateListing() {
   const spreadsheetId = SpreadsheetApp.getActiveSpreadsheet().getId();
   const ui = SpreadsheetApp.getUi();
 
-  const sheet = SpreadsheetApp.getActiveSpreadsheet().getActiveSheet();
+  const ss = SpreadsheetApp.getActiveSpreadsheet();
+  const sheet = ss.getActiveSheet();
+
+  // 出品シート以外は拒否
   if (sheet.getName() !== '出品') {
     ui.alert('エラー', '出品シートを選択してください。', ui.ButtonSet.OK);
     return;
+  }
+
+  // 出品DBからの誤操作を防止
+  // ツール設定の「出品シート」URLと現在のSSを比較
+  try {
+    const ebayConfig = EbayLib.getEbayConfig(spreadsheetId);
+    const listingSheetUrl = String(ebayConfig.listingSheetUrl || '').trim();
+    if (listingSheetUrl) {
+      const listingSheetIdMatch = listingSheetUrl.match(/\/spreadsheets\/d\/([a-zA-Z0-9-_]+)/);
+      if (listingSheetIdMatch && listingSheetIdMatch[1]) {
+        const currentSsId = ss.getId();
+        if (listingSheetIdMatch[1] !== currentSsId) {
+          ui.alert(
+            '❌ 出品不可',
+            'このスプレッドシートからは出品できません。\n出品シートから操作してください。',
+            ui.ButtonSet.OK
+          );
+          return;
+        }
+      }
+    }
+  } catch(configErr) {
+    Logger.log('出品DBチェックエラー（続行）: ' + configErr.toString());
   }
 
   const row = sheet.getActiveRange().getRow();
@@ -81,12 +107,59 @@ function menuCreateListing() {
     return;
   }
 
-  // VEROチェック（出品前）
-  const wordCheck = EbayLib.getWordCheckValue(spreadsheetId, row);
-  if (wordCheck === 'VERO') {
+  // 出品前に強制ワード判定を実行（シートの値に依存せず毎回チェック）
+  const headerMapping = _buildListingHeaderMapping(sheet);
+  const titleCol = headerMapping['タイトル'];
+  const titleForCheck = titleCol
+    ? String(sheet.getRange(row, titleCol).getValue() || '').trim()
+    : '';
+
+  // ワード判定を強制実行して結果を取得
+  let wordCheck = '';
+  try {
+    if (titleForCheck) {
+      wordCheck = EbayLib.forceCheckWordJudgement(spreadsheetId, row, titleForCheck);
+    }
+  } catch(wcErr) {
+    Logger.log('forceCheckWordJudgement エラー（フォールバック）: ' + wcErr.toString());
+  }
+  // フォールバック: シートの既存値を使用
+  if (!wordCheck) {
+    try {
+      wordCheck = String(EbayLib.getWordCheckValue(spreadsheetId, row) || '');
+    } catch(e2) {
+      Logger.log('getWordCheckValue エラー: ' + e2.toString());
+    }
+  }
+  Logger.log('ワード判定結果: ' + wordCheck);
+
+  // 禁止ワードは完全ブロック
+  if (wordCheck && String(wordCheck).indexOf('禁止:') === 0) {
+    ui.alert(
+      '🚫 出品禁止',
+      '禁止ワードが含まれているため出品できません。\n\n' +
+      '判定結果: ' + wordCheck + '\n\n' +
+      'タイトルを修正してから再度出品してください。',
+      ui.ButtonSet.OK
+    );
+    return;
+  }
+
+  // 文字数オーバーは警告のみ
+  if (wordCheck === '文字数オーバー') {
+    const overResponse = ui.alert(
+      '⚠️ 文字数オーバー警告',
+      'タイトルが80文字を超えています。\n出品を続行しますか？',
+      ui.ButtonSet.OK_CANCEL
+    );
+    if (overResponse !== ui.Button.OK) return;
+  }
+
+  // VEROは警告のみ
+  if (wordCheck && String(wordCheck).indexOf('VERO:') === 0) {
     const veroResponse = ui.alert(
       '⚠️ VERO警告',
-      'このアイテムにVEROワードが含まれています。\neBayから削除申請が来る可能性があります。\n\n出品を続行しますか？',
+      'VEROワードが含まれています。\n判定結果: ' + wordCheck + '\n\n出品を続行しますか？',
       ui.ButtonSet.OK_CANCEL
     );
     if (veroResponse !== ui.Button.OK) return;

--- a/gas/listing/container/appsscript.json
+++ b/gas/listing/container/appsscript.json
@@ -1,23 +1,14 @@
 {
   "timeZone": "Asia/Tokyo",
-  "dependencies": {
-    "libraries": [
-      {
-        "userSymbol": "EbayLib",
-        "version": "0",
-        "libraryId": "13B_QVLCmt-KuxsyytDsS-2Ca6S_PLyNb-ZlEVbpg0T5-vEvM3otTLn1Y",
-        "developmentMode": true
-      }
-    ]
-  },
+  "dependencies": {},
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "oauthScopes": [
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/drive",
-    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/script.external_request",
     "https://www.googleapis.com/auth/script.scriptapp",
     "https://www.googleapis.com/auth/script.container.ui",
-    "https://www.googleapis.com/auth/script.external_request"
+    "https://www.googleapis.com/auth/script.storage"
   ]
 }

--- a/gas/listing/standalone/Config.gs
+++ b/gas/listing/standalone/Config.gs
@@ -372,6 +372,7 @@ function getEbayConfig() {
     ruName: config['RuName'] || '',
     categoryMasterSpreadsheetId: extractSpreadsheetId(config['カテゴリマスタ']) || '',
     outputDbSpreadsheetId: extractSpreadsheetId(config['出品DB']) || '',
+    listingSheetUrl: config['出品シート'] || '',
     csvBackupFolderId:     extractDriveFolderId(config['CSVデータフォルダ']) || '',
     itemLocation: config['出品所在地'] || 'Japan',
     postalCode:   config['郵便番号']   || '',

--- a/gas/listing/standalone/ListingManager.gs
+++ b/gas/listing/standalone/ListingManager.gs
@@ -721,60 +721,160 @@ function _getPostalCode(config) {
 }
 
 /**
- * 出品者情報（PostalCode・Location）を PropertiesService に保存
- * ツール設定シートから読み込み、フォーマット検証後に保存する
- * authorizeScript から呼び出す
+ * 出品者情報をeBay APIから取得してツール設定シートに書き込む
+ * 取得対象: 出品所在地・郵便番号・eBayユーザーID・ストアプラン
  *
  * @param {string} spreadsheetId
- * @returns {{ success: boolean, postalCode: string, location: string, message: string }}
+ * @returns {{ success: boolean, message: string }}
  */
 function setupSellerInfo(spreadsheetId) {
   try {
     if (spreadsheetId) CURRENT_SPREADSHEET_ID = spreadsheetId;
 
-    const config     = getEbayConfig();
-    const postalCode = String(config.postalCode || '').trim();
-    const location   = String(config.itemLocation || 'Japan').trim();
+    autoRefreshTokenIfNeeded(spreadsheetId);
+    if (spreadsheetId) CURRENT_SPREADSHEET_ID = spreadsheetId;
 
-    if (postalCode === '') {
+    const config = getEbayConfig();
+    const token  = config.userToken;
+    const apiUrl = 'https://api.ebay.com/ws/api.dll';
+
+    // GetUser APIで出品者情報を取得
+    const xmlRequest =
+      '<?xml version="1.0" encoding="utf-8"?>' +
+      '<GetUserRequest xmlns="urn:ebay:apis:eBLBaseComponents">' +
+      '<RequesterCredentials>' +
+      '<eBayAuthToken>' + token + '</eBayAuthToken>' +
+      '</RequesterCredentials>' +
+      '<DetailLevel>ReturnAll</DetailLevel>' +
+      '</GetUserRequest>';
+
+    const response = UrlFetchApp.fetch(apiUrl, {
+      method: 'POST',
+      headers: {
+        'X-EBAY-API-CALL-NAME':          'GetUser',
+        'X-EBAY-API-SITEID':             '0',
+        'X-EBAY-API-COMPATIBILITY-LEVEL':'967',
+        'X-EBAY-API-APP-NAME':           config.appId,
+        'X-EBAY-API-DEV-NAME':           config.devId,
+        'X-EBAY-API-CERT-NAME':          config.certId,
+        'Content-Type':                  'text/xml'
+      },
+      payload: xmlRequest,
+      muteHttpExceptions: true
+    });
+
+    const ns   = XmlService.getNamespace('urn:ebay:apis:eBLBaseComponents');
+    const root = XmlService.parse(response.getContentText()).getRootElement();
+    const ack  = root.getChildText('Ack', ns);
+
+    if (ack !== 'Success' && ack !== 'Warning') {
+      const errEl  = root.getChild('Errors', ns);
+      const errMsg = errEl ? errEl.getChildText('ShortMessage', ns) : '不明なエラー';
+      return { success: false, message: 'eBay APIエラー: ' + errMsg };
+    }
+
+    // ユーザー情報を取得
+    const userEl                = root.getChild('User', ns);
+    const userId                = userEl ? userEl.getChildText('UserID', ns) || '' : '';
+    const registrationAddressEl = userEl ? userEl.getChild('RegistrationAddress', ns) : null;
+    const city                  = registrationAddressEl ? registrationAddressEl.getChildText('CityName', ns)       || '' : '';
+    const stateOrProvince       = registrationAddressEl ? registrationAddressEl.getChildText('StateOrProvince', ns) || '' : '';
+    const postalCode            = registrationAddressEl ? registrationAddressEl.getChildText('PostalCode', ns)      || '' : '';
+
+    // 出品所在地を組み立て（City + State/Province）
+    const itemLocation = [city, stateOrProvince].filter(Boolean).join(' ');
+
+    // ストアプランを取得（GetStoreで確認）
+    let storePlan = '（なし）';
+    try {
+      const storeXml =
+        '<?xml version="1.0" encoding="utf-8"?>' +
+        '<GetStoreRequest xmlns="urn:ebay:apis:eBLBaseComponents">' +
+        '<RequesterCredentials>' +
+        '<eBayAuthToken>' + token + '</eBayAuthToken>' +
+        '</RequesterCredentials>' +
+        '</GetStoreRequest>';
+
+      const storeResponse = UrlFetchApp.fetch(apiUrl, {
+        method: 'POST',
+        headers: {
+          'X-EBAY-API-CALL-NAME':          'GetStore',
+          'X-EBAY-API-SITEID':             '0',
+          'X-EBAY-API-COMPATIBILITY-LEVEL':'967',
+          'X-EBAY-API-APP-NAME':           config.appId,
+          'X-EBAY-API-DEV-NAME':           config.devId,
+          'X-EBAY-API-CERT-NAME':          config.certId,
+          'Content-Type':                  'text/xml'
+        },
+        payload: storeXml,
+        muteHttpExceptions: true
+      });
+
+      const storeRoot = XmlService.parse(storeResponse.getContentText()).getRootElement();
+      const storeAck  = storeRoot.getChildText('Ack', ns);
+      if (storeAck === 'Success' || storeAck === 'Warning') {
+        const storeEl        = storeRoot.getChild('Store', ns);
+        const subscriptionEl = storeEl ? storeEl.getChild('Subscription', ns) : null;
+        const level          = subscriptionEl ? subscriptionEl.getChildText('Level', ns) || '' : '';
+        if (level) storePlan = level;
+      }
+    } catch(storeErr) {
+      Logger.log('GetStore エラー（続行）: ' + storeErr.toString());
+    }
+
+    Logger.log('取得結果: ユーザーID=' + userId + ' 所在地=' + itemLocation +
+               ' 郵便番号=' + postalCode + ' ストアプラン=' + storePlan);
+
+    // ツール設定シートに書き込む
+    const ss            = getTargetSpreadsheet(spreadsheetId);
+    const settingsSheet = ss.getSheetByName('ツール設定');
+    if (!settingsSheet) {
+      return { success: false, message: 'ツール設定シートが見つかりません。' };
+    }
+
+    const data     = settingsSheet.getDataRange().getValues();
+    const headers  = data[0];
+    const itemIdx  = headers.findIndex(function(h) { return String(h || '').trim() === '項目'; });
+    const valueIdx = headers.findIndex(function(h) { return String(h || '').trim() === '値'; });
+
+    if (itemIdx === -1 || valueIdx === -1) {
+      return { success: false, message: 'ツール設定シートに「項目」「値」列が見つかりません。' };
+    }
+
+    // 書き込みマップ（項目名 → 値）
+    const writeMap = {};
+    if (itemLocation) writeMap['出品所在地']    = itemLocation;
+    if (postalCode)   writeMap['郵便番号']       = postalCode.replace(/-/g, '');
+    if (userId)       writeMap['eBayユーザーID'] = userId;
+    if (storePlan)    writeMap['ストアプラン']   = storePlan;
+
+    const updatedKeys = [];
+    for (let i = 1; i < data.length; i++) {
+      const key = String(data[i][itemIdx] || '').trim();
+      if (writeMap.hasOwnProperty(key)) {
+        settingsSheet.getRange(i + 1, valueIdx + 1).setValue(writeMap[key]);
+        updatedKeys.push(key + ': ' + writeMap[key]);
+        Logger.log('✅ 書き込み: ' + key + ' = ' + writeMap[key]);
+      }
+    }
+
+    if (updatedKeys.length === 0) {
       return {
         success: false,
-        postalCode: '',
-        location: location,
-        message: '⚠️ ツール設定シートの「郵便番号」が未入力です。⚙️ → アカウント情報取得 を先に実行してください。'
+        message: 'ツール設定シートに以下の項目が見つかりません:\n' +
+                 Object.keys(writeMap).join('\n') +
+                 '\n\nツール設定シートに項目を追加してください。'
       };
     }
 
-    // ハイフンなし7桁（例: 4442141）→ 自動フォーマット（444-2141）
-    const digitsOnly     = postalCode.replace(/-/g, '');
-    const normalizedCode = digitsOnly.length === 7
-      ? digitsOnly.slice(0, 3) + '-' + digitsOnly.slice(3)
-      : postalCode;
-
-    // 日本の郵便番号フォーマット検証（XXX-XXXX）
-    if (!/^\d{3}-\d{4}$/.test(normalizedCode)) {
-      return {
-        success: false,
-        postalCode: postalCode,
-        location: location,
-        message: '⚠️ 郵便番号のフォーマットが不正です（' + postalCode + '）。XXX-XXXX 形式（7桁）で入力してください。'
-      };
-    }
-
-    const props = PropertiesService.getScriptProperties();
-    props.setProperty('POSTAL_CODE',   normalizedCode);
-    props.setProperty('ITEM_LOCATION', location);
-
-    Logger.log('✅ setupSellerInfo: PostalCode=' + normalizedCode + ' Location=' + location);
     return {
       success: true,
-      postalCode: normalizedCode,
-      location: location,
-      message: '✅ 出品者情報を保存しました\n郵便番号: ' + normalizedCode + '\n出品所在地: ' + location
+      message: '✅ 出品者情報を更新しました。\n\n' + updatedKeys.join('\n')
     };
-  } catch (e) {
+
+  } catch(e) {
     Logger.log('❌ setupSellerInfo エラー: ' + e.toString());
-    return { success: false, postalCode: '', location: '', message: '❌ ' + e.toString() };
+    return { success: false, message: 'エラー: ' + e.toString() };
   } finally {
     CURRENT_SPREADSHEET_ID = null;
   }

--- a/gas/listing/standalone/ListingManager.gs
+++ b/gas/listing/standalone/ListingManager.gs
@@ -2679,3 +2679,80 @@ function testTransferToOutputDb() {
   }
 }
 
+function fetchRecentListings() {
+  try {
+    const spreadsheetId = PropertiesService.getScriptProperties()
+      .getProperty('DEFAULT_SPREADSHEET_ID');
+    if (spreadsheetId) CURRENT_SPREADSHEET_ID = spreadsheetId;
+
+    autoRefreshTokenIfNeeded(spreadsheetId);
+    if (spreadsheetId) CURRENT_SPREADSHEET_ID = spreadsheetId;
+
+    const config = getEbayConfig();
+    const token = config.userToken;
+
+    // GetSellerList で直近24時間の出品を取得
+    const now = new Date();
+    const yesterday = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+
+    const xmlRequest = '<?xml version="1.0" encoding="utf-8"?>' +
+      '<GetSellerListRequest xmlns="urn:ebay:apis:eBLBaseComponents">' +
+      '<RequesterCredentials>' +
+      '<eBayAuthToken>' + token + '</eBayAuthToken>' +
+      '</RequesterCredentials>' +
+      '<StartTimeFrom>' + yesterday.toISOString() + '</StartTimeFrom>' +
+      '<StartTimeTo>' + now.toISOString() + '</StartTimeTo>' +
+      '<DetailLevel>ReturnAll</DetailLevel>' +
+      '<Pagination>' +
+      '<EntriesPerPage>10</EntriesPerPage>' +
+      '<PageNumber>1</PageNumber>' +
+      '</Pagination>' +
+      '<IncludeItemSpecifics>true</IncludeItemSpecifics>' +
+      '</GetSellerListRequest>';
+
+    const response = UrlFetchApp.fetch('https://api.ebay.com/ws/api.dll', {
+      method: 'POST',
+      headers: {
+        'X-EBAY-API-CALL-NAME': 'GetSellerList',
+        'X-EBAY-API-SITEID': '0',
+        'X-EBAY-API-COMPATIBILITY-LEVEL': '967',
+        'X-EBAY-API-APP-NAME': config.appId,
+        'X-EBAY-API-DEV-NAME': config.devId,
+        'X-EBAY-API-CERT-NAME': config.certId,
+        'Content-Type': 'text/xml'
+      },
+      payload: xmlRequest,
+      muteHttpExceptions: true
+    });
+
+    const ns = XmlService.getNamespace('urn:ebay:apis:eBLBaseComponents');
+    const root = XmlService.parse(response.getContentText()).getRootElement();
+    const ack = root.getChildText('Ack', ns);
+
+    Logger.log('Ack: ' + ack);
+
+    const itemArray = root.getChild('ItemArray', ns);
+    if (!itemArray) {
+      Logger.log('ItemArrayが見つかりません');
+      return;
+    }
+
+    const items = itemArray.getChildren('Item', ns);
+    Logger.log('取得件数: ' + items.length + '件');
+
+    items.forEach(function(item) {
+      const itemId = item.getChildText('ItemID', ns);
+      const title = item.getChildText('Title', ns);
+      const price = item.getChild('StartPrice', ns)
+        ? item.getChild('StartPrice', ns).getText() : '';
+      const startTime = item.getChildText('ListingDetails') || '';
+      Logger.log('Item ID: ' + itemId + ' / タイトル: ' + title + ' / 価格: $' + price);
+    });
+
+  } catch(e) {
+    Logger.log('エラー: ' + e.toString());
+  } finally {
+    CURRENT_SPREADSHEET_ID = null;
+  }
+}
+

--- a/gas/listing/standalone/appsscript.json
+++ b/gas/listing/standalone/appsscript.json
@@ -3,13 +3,11 @@
   "dependencies": {},
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
-  "executionApi": {
-    "access": "MYSELF"
-  },
   "oauthScopes": [
     "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive",
     "https://www.googleapis.com/auth/script.external_request",
-    "https://www.googleapis.com/auth/script.container.ui",
-    "https://www.googleapis.com/auth/script.projects"
+    "https://www.googleapis.com/auth/script.scriptapp",
+    "https://www.googleapis.com/auth/script.storage"
   ]
 }

--- a/gas/research/container/Config.gs
+++ b/gas/research/container/Config.gs
@@ -78,6 +78,17 @@ const RESEARCH_PRICE_INFO = {
   }
 };
 
+// RESEARCH_PRICE_INFO のヘッダー名定義（列番号に依存しない動的取得用）
+const RESEARCH_PRICE_INFO_HEADERS = {
+  PURCHASE_KEYWORD: '仕入れキーワード',
+  PURCHASE_URL1:    '仕入元URL①',
+  PURCHASE_URL2:    '仕入元URL②',
+  PURCHASE_URL3:    '仕入元URL③',
+  IMAGE_URL:        '画像URL',
+  CONDITION_DESC:   '状態説明欄',
+  MEMO:             'メモ'
+};
+
 // B7:P8 - 商品リストセクション
 const RESEARCH_ITEM_LIST = {
   HEADER_ROW: 7,

--- a/gas/research/container/Functions.gs
+++ b/gas/research/container/Functions.gs
@@ -981,12 +981,23 @@ function getDefaultPolicies(ss) {
     if (lastRow < 2) return defaults;
 
     const headers    = policySheet.getRange(1, 1, 1, lastCol).getValues()[0];
-    const typeIdx    = headers.findIndex(function(h) { return String(h || '').trim() === 'POLICY_TYPE'; });
-    const nameIdx    = headers.findIndex(function(h) { return String(h || '').trim() === 'POLICY_NAME'; });
-    const defaultIdx = headers.findIndex(function(h) { return String(h || '').trim() === 'デフォルト'; });
+    // 日本語・英語両方のヘッダー名に対応
+    const typeIdx = headers.findIndex(function(h) {
+      const v = String(h || '').trim();
+      return v === 'POLICY_TYPE' || v === 'ポリシータイプ';
+    });
+    const nameIdx = headers.findIndex(function(h) {
+      const v = String(h || '').trim();
+      return v === 'POLICY_NAME' || v === 'ポリシー名';
+    });
+    const defaultIdx = headers.findIndex(function(h) {
+      const v = String(h || '').trim();
+      return v === 'デフォルト';
+    });
 
     if (typeIdx === -1 || nameIdx === -1 || defaultIdx === -1) {
-      Logger.log('⚠️ ポリシー管理シートに必要な列が見つかりません（POLICY_TYPE/POLICY_NAME/デフォルト）');
+      Logger.log('⚠️ ポリシー管理シートに必要な列が見つかりません' +
+        '（typeIdx=' + typeIdx + ' nameIdx=' + nameIdx + ' defaultIdx=' + defaultIdx + '）');
       return defaults;
     }
 

--- a/gas/research/container/Functions.gs
+++ b/gas/research/container/Functions.gs
@@ -198,13 +198,36 @@ function prepareTransferDataWithMapping(itemInfo, specInfo, listingSheet, header
     volumetricWeight: researchSheet.getRange(RESEARCH_MAIN_INFO.DATA_ROW, RESEARCH_MAIN_INFO.COLUMNS.VOLUMETRIC_WEIGHT_G.col).getValue()
   };
 
+  // 10行目（ヘッダー行）からマッピングを構築
+  const priceInfoHeaderRow = researchSheet.getRange(
+    RESEARCH_PRICE_INFO.HEADER_ROW, 1, 1, researchSheet.getLastColumn()
+  ).getValues()[0];
+
+  const priceInfoMap = {};
+  priceInfoHeaderRow.forEach(function(h, i) {
+    const header = String(h || '').trim();
+    if (header) priceInfoMap[header] = i + 1; // 1-based
+  });
+  Logger.log('priceInfoMap: ' + JSON.stringify(priceInfoMap));
+
+  // ヘッダー名で列を動的取得
+  function getPriceInfoValue(headerName) {
+    const col = priceInfoMap[headerName];
+    if (!col) {
+      Logger.log('⚠️ priceInfo列が見つかりません: ' + headerName);
+      return '';
+    }
+    return researchSheet.getRange(RESEARCH_PRICE_INFO.DATA_ROW, col).getValue() || '';
+  }
+
   const priceInfo = {
-    purchaseKeyword: researchSheet.getRange(RESEARCH_PRICE_INFO.DATA_ROW, RESEARCH_PRICE_INFO.COLUMNS.PURCHASE_KEYWORD.col).getValue(),
-    purchaseUrl1: researchSheet.getRange(RESEARCH_PRICE_INFO.DATA_ROW, RESEARCH_PRICE_INFO.COLUMNS.PURCHASE_URL_1.col).getValue(),
-    purchaseUrl2: researchSheet.getRange(RESEARCH_PRICE_INFO.DATA_ROW, RESEARCH_PRICE_INFO.COLUMNS.PURCHASE_URL_2.col).getValue(),
-    purchaseUrl3: researchSheet.getRange(RESEARCH_PRICE_INFO.DATA_ROW, RESEARCH_PRICE_INFO.COLUMNS.PURCHASE_URL_3.col).getValue(),
-    memo: researchSheet.getRange(RESEARCH_PRICE_INFO.DATA_ROW, RESEARCH_PRICE_INFO.COLUMNS.MEMO.col).getValue(),
-    imageUrl: researchSheet.getRange(RESEARCH_PRICE_INFO.DATA_ROW, RESEARCH_PRICE_INFO.COLUMNS.IMAGE_URL.col).getValue()
+    purchaseKeyword: getPriceInfoValue(RESEARCH_PRICE_INFO_HEADERS.PURCHASE_KEYWORD),
+    purchaseUrl1:    getPriceInfoValue(RESEARCH_PRICE_INFO_HEADERS.PURCHASE_URL1),
+    purchaseUrl2:    getPriceInfoValue(RESEARCH_PRICE_INFO_HEADERS.PURCHASE_URL2),
+    purchaseUrl3:    getPriceInfoValue(RESEARCH_PRICE_INFO_HEADERS.PURCHASE_URL3),
+    imageUrl:        getPriceInfoValue(RESEARCH_PRICE_INFO_HEADERS.IMAGE_URL),
+    conditionDesc:   getPriceInfoValue(RESEARCH_PRICE_INFO_HEADERS.CONDITION_DESC),
+    memo:            getPriceInfoValue(RESEARCH_PRICE_INFO_HEADERS.MEMO)
   };
 
   const itemList = {
@@ -353,9 +376,9 @@ function prepareTransferDataWithMapping(itemInfo, specInfo, listingSheet, header
   // 状態
   setValueByHeader(LISTING_COLUMNS.CONDITION.header, itemList.condition);
 
-  // 状態説明（空）
+  // 状態説明（リサーチシートの「状態説明欄」列から取得・なければ空）
   setValueByHeader(LISTING_COLUMNS.CONDITION_DESC_TEMPLATE.header, '');
-  setValueByHeader(LISTING_COLUMNS.CONDITION_DESC_2.header, '');
+  setValueByHeader(LISTING_COLUMNS.CONDITION_DESC_2.header, priceInfo.conditionDesc || '');
   setValueByHeader(LISTING_COLUMNS.DESCRIPTION.header, '');
 
   // ItemURL

--- a/gas/research/container/Functions.gs
+++ b/gas/research/container/Functions.gs
@@ -902,16 +902,56 @@ function transferListingDataWithPolicy(policyRow, policyLabel) {
 }
 
 /**
- * ポリシー管理シートから「デフォルト」列が"デフォルト"の
- * ポリシー名をタイプ別に取得する
- * @param {Spreadsheet} ss 出品スプレッドシート
+ * 出品シートのポリシー管理シートからデフォルトポリシーを取得
+ * @param {Spreadsheet} ss リサーチスプレッドシート（ツール設定シートを持つ）
  * @returns {{ shipping: string, return: string, payment: string }}
  */
 function getDefaultPolicies(ss) {
   const defaults = { shipping: '', return: '', payment: '' };
   try {
-    const policySheet = ss.getSheetByName('ポリシー管理');
-    if (!policySheet) return defaults;
+    // ツール設定シートから出品シートURLを取得
+    const toolSheet = ss.getSheetByName('ツール設定');
+    if (!toolSheet) {
+      Logger.log('⚠️ ツール設定シートが見つかりません');
+      return defaults;
+    }
+
+    const toolData   = toolSheet.getDataRange().getValues();
+    const toolHeaders = toolData[0];
+    const itemIdx  = toolHeaders.findIndex(function(h) { return String(h || '').trim() === '項目'; });
+    const valueIdx = toolHeaders.findIndex(function(h) { return String(h || '').trim() === '値'; });
+
+    if (itemIdx === -1 || valueIdx === -1) {
+      Logger.log('⚠️ ツール設定シートに項目/値列が見つかりません');
+      return defaults;
+    }
+
+    let listingSheetUrl = '';
+    for (let i = 1; i < toolData.length; i++) {
+      const key = String(toolData[i][itemIdx] || '').trim();
+      if (key === '出品シート') {
+        listingSheetUrl = String(toolData[i][valueIdx] || '').trim();
+        break;
+      }
+    }
+
+    if (!listingSheetUrl) {
+      Logger.log('⚠️ ツール設定シートに出品シートURLが設定されていません');
+      return defaults;
+    }
+
+    const match = listingSheetUrl.match(/\/spreadsheets\/d\/([a-zA-Z0-9-_]+)/);
+    if (!match || !match[1]) {
+      Logger.log('⚠️ 出品シートURLからIDを抽出できません');
+      return defaults;
+    }
+
+    const listingSS   = SpreadsheetApp.openById(match[1]);
+    const policySheet = listingSS.getSheetByName('ポリシー管理');
+    if (!policySheet) {
+      Logger.log('⚠️ 出品シートにポリシー管理シートが見つかりません');
+      return defaults;
+    }
 
     const lastRow = policySheet.getLastRow();
     const lastCol = policySheet.getLastColumn();
@@ -947,6 +987,7 @@ function getDefaultPolicies(ss) {
     Logger.log('デフォルトポリシー: Shipping=' + defaults.shipping +
                ' Return=' + defaults.return +
                ' Payment=' + defaults.payment);
+
   } catch(e) {
     Logger.log('getDefaultPolicies エラー: ' + e.toString());
   }

--- a/gas/research/container/Functions.gs
+++ b/gas/research/container/Functions.gs
@@ -474,6 +474,36 @@ function prepareTransferDataWithMapping(itemInfo, specInfo, listingSheet, header
   // 管理年月（空）
   setValueByHeader(LISTING_COLUMNS.MGMT_YEAR_MONTH.header, '');
 
+  // ポリシー管理シートからデフォルトポリシーを取得して補完
+  const defaultPolicies = getDefaultPolicies(listingSheet.getParent());
+
+  const shippingPolicyKey = 'Shipping Policy';
+  if (headerMapping[shippingPolicyKey] &&
+      (!transferData[headerMapping[shippingPolicyKey] - 1] ||
+       String(transferData[headerMapping[shippingPolicyKey] - 1]).trim() === '') &&
+      defaultPolicies.shipping) {
+    transferData[headerMapping[shippingPolicyKey] - 1] = defaultPolicies.shipping;
+    Logger.log('デフォルトShipping Policy補完: ' + defaultPolicies.shipping);
+  }
+
+  const returnPolicyKey = 'Return Policy';
+  if (headerMapping[returnPolicyKey] &&
+      (!transferData[headerMapping[returnPolicyKey] - 1] ||
+       String(transferData[headerMapping[returnPolicyKey] - 1]).trim() === '') &&
+      defaultPolicies.return) {
+    transferData[headerMapping[returnPolicyKey] - 1] = defaultPolicies.return;
+    Logger.log('デフォルトReturn Policy補完: ' + defaultPolicies.return);
+  }
+
+  const paymentPolicyKey = 'Payment Policy';
+  if (headerMapping[paymentPolicyKey] &&
+      (!transferData[headerMapping[paymentPolicyKey] - 1] ||
+       String(transferData[headerMapping[paymentPolicyKey] - 1]).trim() === '') &&
+      defaultPolicies.payment) {
+    transferData[headerMapping[paymentPolicyKey] - 1] = defaultPolicies.payment;
+    Logger.log('デフォルトPayment Policy補完: ' + defaultPolicies.payment);
+  }
+
   return {
     data: transferData,
     specColors: specColors
@@ -869,5 +899,57 @@ function transferListingDataWithPolicy(policyRow, policyLabel) {
 
     SpreadsheetApp.getUi().alert('転記エラー:\n\n' + error.toString());
   }
+}
+
+/**
+ * ポリシー管理シートから「デフォルト」列が"デフォルト"の
+ * ポリシー名をタイプ別に取得する
+ * @param {Spreadsheet} ss 出品スプレッドシート
+ * @returns {{ shipping: string, return: string, payment: string }}
+ */
+function getDefaultPolicies(ss) {
+  const defaults = { shipping: '', return: '', payment: '' };
+  try {
+    const policySheet = ss.getSheetByName('ポリシー管理');
+    if (!policySheet) return defaults;
+
+    const lastRow = policySheet.getLastRow();
+    const lastCol = policySheet.getLastColumn();
+    if (lastRow < 2) return defaults;
+
+    const headers    = policySheet.getRange(1, 1, 1, lastCol).getValues()[0];
+    const typeIdx    = headers.findIndex(function(h) { return String(h || '').trim() === 'POLICY_TYPE'; });
+    const nameIdx    = headers.findIndex(function(h) { return String(h || '').trim() === 'POLICY_NAME'; });
+    const defaultIdx = headers.findIndex(function(h) { return String(h || '').trim() === 'デフォルト'; });
+
+    if (typeIdx === -1 || nameIdx === -1 || defaultIdx === -1) {
+      Logger.log('⚠️ ポリシー管理シートに必要な列が見つかりません（POLICY_TYPE/POLICY_NAME/デフォルト）');
+      return defaults;
+    }
+
+    const data = policySheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
+    data.forEach(function(row) {
+      const type      = String(row[typeIdx]    || '').trim().toLowerCase();
+      const name      = String(row[nameIdx]    || '').trim();
+      const isDefault = String(row[defaultIdx] || '').trim() === 'デフォルト';
+
+      if (!isDefault || !name) return;
+
+      if (type.indexOf('fulfillment') !== -1 || type.indexOf('shipping') !== -1) {
+        if (!defaults.shipping) defaults.shipping = name;
+      } else if (type.indexOf('return') !== -1) {
+        if (!defaults.return) defaults.return = name;
+      } else if (type.indexOf('payment') !== -1) {
+        if (!defaults.payment) defaults.payment = name;
+      }
+    });
+
+    Logger.log('デフォルトポリシー: Shipping=' + defaults.shipping +
+               ' Return=' + defaults.return +
+               ' Payment=' + defaults.payment);
+  } catch(e) {
+    Logger.log('getDefaultPolicies エラー: ' + e.toString());
+  }
+  return defaults;
 }
 


### PR DESCRIPTION
## 変更内容

### 出品コア機能
- SKU予約方式でDB転記の行番号ずれを解消
- eBay Media API実装・Google Drive画像を自動アップロード（EPS URL書き戻し）
- Item ID日付誤認識修正（getDisplayValue）
- 出品ステータスを日本語化（出品中/出品終了/在庫切れ）
- 在庫切れ処理実装（eBay数量0・シート更新）
- 更新機能を出品DB対応に変更（タイムスタンプをDBに書き込み）
- setupSellerInfo()をeBay API（GetUser/GetStore）から情報取得に変更
- 出品DBからの出品防止・禁止ワード強制チェック実装
- 出品前の禁止ワード/VERO/文字数オーバー3段階チェック

### onEdit機能強化
- タイトル編集時にVero/禁止ワード自動判定（80文字超過も検知）
- 状態テンプレ選択時に状態説明を自動転記
- 発送業者変更時に発送方法プルダウンを連動展開
- handleEdit()の処理順序修正

### リサーチシート転記
- デフォルトポリシー自動補完（ポリシー管理シートのデフォルト列から取得）
- 状態説明欄をヘッダー名マッピングで動的取得・出品シートに転記
- getDefaultPolicies()を出品シートのポリシー管理シートを参照するよう修正
- getDefaultPolicies()ヘッダー名を日本語対応（ポリシータイプ・ポリシー名）

### セルスタCSV出力
- 出品ステータス=出品中・出品URLあり・CSV空の行をフィルタ
- ヘッダー名マッピングで列ずれ防止
- Googleドライブにバックアップ保存・自動ダウンロード

### シート同期・報酬管理
- 出品SS↔出品DBの双方向シート同期（copyTo方式）
- 管理年月プルダウン自動更新
- 担当者ごとの業務別作業件数集計・報酬計算

### コード品質改善
- appsscript.jsonスコープ最小化（不要スコープ削除・script.storage追加）
- 全ての列番号ハードコードをヘッダー名マッピングに変更
- 担当者管理の業務名をD-K列の単価ヘッダーから動的取得
- OAuth認証URLメニューを追加
- fetchRecentListings()テスト関数追加（本番前に削除要）