### PR TITLE
feat: category_master descriptor_type列追加・トレカ出品ConditionDescriptors必須バリデーション

### DIFF
--- a/docs/evidence/pr46-evidence.md
+++ b/docs/evidence/pr46-evidence.md
@@ -1,0 +1,265 @@
+# PR #46 エビデンス文書
+# category_master × ConditionDescriptors 連携実装
+
+**作成日**: 2026-05-02  
+**対象PR**: #46  
+**前提PR**: #45 (ConditionDescriptors送信実装)
+
+---
+
+## E1: eBay公式ドキュメントの確認
+
+### E1-1: ConditionDescriptors が必須となるカテゴリの公式定義
+
+**公式ソース**: [Condition Descriptor IDs for Trading Cards | eBay Developers Program](https://developer.ebay.com/api-docs/user-guides/static/mip-user-guide/mip-enum-condition-descriptor-ids-for-trading-cards.html)
+
+> "For trading card listings in **Non-Sport Trading Card Singles (183050)**, **CCG Individual Cards (183454)**, and **Sports Trading Card Singles (261328)** categories, sellers must use either LIKE_NEW (2750) or USED_VERY_GOOD (4000) item condition to specify the card as Graded or Ungraded, respectively."
+
+> "If either of these condition IDs are used, the seller is required to use this container to provide one or more applicable Condition Descriptor name-value pairs."
+
+**参考**: [ConditionDescriptorsType - Trading API Reference](https://developer.ebay.com/devzone/xml/docs/reference/ebay/types/ConditionDescriptorsType.html)
+
+**結論**: 3カテゴリが公式に明示されている。
+
+### E1-2: 各ConditionIDのConditionDescriptors要件
+
+#### ConditionID 2750 (Graded) — ConditionDescriptors 必須
+
+**公式ソース**: [eBay Connect 2023 Condition Grading - Trading Cards](https://developer.ebay.com/cms/files/connect-2023/condition_grading_trading_cards.pdf)
+
+> "When using Condition ID 2750 (Graded) for trading cards, the seller is required to use the ConditionDescriptors container to provide one or more applicable Condition Descriptor name-value pairs."
+> "For graded cards, the condition descriptors for Grader and Grade are **required**, while the condition descriptor for Certification Number is optional."
+
+**XMLフォーマット**:
+```xml
+<ConditionID>2750</ConditionID>
+<ConditionDescriptors>
+  <ConditionDescriptor>
+    <Name>27501</Name>  <!-- Grader -->
+    <Value>275010</Value>  <!-- PSA=275010, BGS=275013, SGC=275016 ... -->
+  </ConditionDescriptor>
+  <ConditionDescriptor>
+    <Name>27502</Name>  <!-- Grade -->
+    <Value>275020</Value>  <!-- 10=275020, 9.5=275021, ... 5.5=275029 -->
+  </ConditionDescriptor>
+  <!-- Name=27503 (Cert No) は任意 -->
+</ConditionDescriptors>
+```
+
+#### ConditionID 4000 (Ungraded) — Name=40001 が必須
+
+**公式ソース**: [Condition Descriptor IDs for Trading Cards](https://developer.ebay.com/api-docs/user-guides/static/mip-user-guide/mip-enum-condition-descriptor-ids-for-trading-cards.html)
+
+> "If the card is ungraded, enter 4000 in ConditionID. The ID **40001** represents the ungraded condition in categories 183050, 183454, and 261328."
+
+**有効値**:
+| Value | 表示 |
+|-------|------|
+| 400010 | Near Mint or Better |
+| 400011 | Excellent (Lightly Played) |
+| 400012 | Very Good (Moderately Played) |
+| 400013 | Poor (Heavily Played) |
+
+**XMLフォーマット**:
+```xml
+<ConditionID>4000</ConditionID>
+<ConditionDescriptors>
+  <ConditionDescriptor>
+    <Name>40001</Name>
+    <Value>400010</Value>
+  </ConditionDescriptor>
+</ConditionDescriptors>
+```
+
+### E1-3: ConditionID 3000 (Used) — 2023年に廃止
+
+**公式アナウンス**: eBay Developer Program (2023年)
+
+> "After **October 23, 2023**: NO new listings, relists, or revisions will be accepted in the trading card (singles) categories if they do not adhere to eBay's new Condition policies."
+> "By **January 22, 2024**: ALL existing listings must be modified to include Condition Descriptors."
+
+**実証**: Trading API エラー 21920350
+> "Condition information 3000 does not exists or is not a valid condition for category 183454"
+
+**参考**: [eBay Community - Error Code 21920350](https://community.ebay.com/t5/Traditional-APIs-Selling/Error-Code-21920350-Condition-information-3000-is-not-valid-for/td-p/34307514)
+
+**現状**: Sell Metadata API は依然 3000 を有効として返す（APIの不整合）。  
+Trading API では拒否されるため、category_master の conditions_json は不正確な情報を含む。  
+→ `known_invalid_conditions` 列 (Phase 3候補) でこの不整合を管理予定。
+
+### E1-4: is_trading_card_group() の判定ロジック妥当性検証
+
+**既存ロジック** (`generate_csv.py`):
+```python
+def is_trading_card_group(ids: frozenset) -> bool:
+    return (
+        {"2750", "4000"}.issubset(ids)
+        and not ids.intersection({"5000", "6000", "7000", "2500"})
+    )
+```
+
+**設計根拠**:
+- 2750 (Graded) + 4000 (Ungraded) = トレカカテゴリの必要条件（eBay公式から）
+- 5000/6000/7000 = 一般中古品コンディション（トレカカテゴリには存在しない）
+- 2500 = Seller Refurbished（トレカカテゴリには存在しない）
+
+**EBAY_US での実データ検証結果** (category_master_EBAY_US.csv 45,915行から):
+
+```
+graded_card 該当カテゴリ: 8件
+  261328  Trading Card Singles        [2750, 3000, 4000]  ← 本番利用
+  183454  CCG Individual Cards        [2750, 3000, 4000]  ← 本番利用（メイン対象）
+  183050  Trading Card Singles        [2750, 3000, 4000]  ← 本番利用
+  178089  Category 2                  [1000, 2750, 4000]  ← テスト/sandbox
+  37563   Attributes6_Test            [2750, 4000]        ← テストカテゴリ
+  37566   Attributes8                 [2750, 3000, 4000]  ← テストカテゴリ
+  37567   Attributes9                 [2750, 3000, 4000]  ← テストカテゴリ
+  37568   Attributes10                [2750, 3000, 4000]  ← テストカテゴリ
+```
+
+**誤検知の検証**:
+- 37xxx番台と178089はeBay sandbox/テスト用カテゴリ。本番出品では使用されない
+- 実際に顧客が使用するカテゴリ: 261328, 183454, 183050 の3件
+- 誤検知なし（非トレカカテゴリで 2750+4000 が含まれるケースは存在しない）
+
+**見落としの検証**:
+- Group E: [2750, 4000, 5000, 6000, 7000, ...] → `is_trading_card_group` = FALSE（正しく除外）
+- Group G: [2750, 4000, 5000, 6000] → FALSE（正しく除外）
+- これらは一般中古品カテゴリ（Magazines, Posters等）であり除外が正しい
+
+**結論**: 判定ロジックは正確に機能している。
+
+### E1-5: PR #45 実機検証結果（最強エビデンス）
+
+`docs/investigations/ebay-condition-descriptors-verification-20260501.md` より:
+
+| ケース | カテゴリ | ConditionID | ConditionDescriptors | 結果 |
+|--------|----------|-------------|----------------------|------|
+| 1 | 183454 | 2750 (Graded) | Grader=PSA, Grade=10 | ✅ 出品成功 |
+| 3 | 183454 | 4000 (Ungraded) | Name=40001, Value=400010 | ✅ 出品成功 |
+| 4 | 183454 | 4000 (Ungraded) | DescriptorsなしCGC | ❌ エラー21920355 |
+| 5 | 183454 | 3000 (Used) | なし | ❌ エラー21920350 |
+
+**エラー21920355の意味**: Ungraded (4000) でConditionDescriptors未指定は拒否される
+
+---
+
+## E2: 既存の設計課題の記録
+
+### E2-1: condition_group のラベル不一致
+
+**問題**: category_master CSV と condition_ja_map でグループラベルが一致しない
+
+| データソース | [2750, 3000, 4000] セットのラベル | 生成タイミング |
+|---|---|---|
+| category_master_EBAY_US.csv (generate_csv.py) | N (動的割り当て) | 月次同期時に全カテゴリ横断で再割当 |
+| condition_ja_map (SyncCategoryMaster.gs ハードコード) | O (固定) | 2026-04-10 時点スナップショット |
+
+**影響範囲**:
+- `ConditionDropdown.gs` は condition_group を使って condition_ja_map を引く
+- ラベル不一致の場合、トレカカテゴリの Condition ドロップダウンが正しく機能しない可能性
+- `ImportSync.gs` の `checkConditionIdExists()` で "condition_group が未登録" エラーが出る可能性
+
+**根本原因**: `importConditionJaMap()` は手動実行専用のハードコード書き込み関数であり、`generate_csv.py` が動的にグループラベルを割り当てるロジックと同期していない
+
+**PR #46 での対応方針**: 今回スコープ外として別issueで管理する  
+**理由**: PR #46 の `descriptor_type` は `conditions_json` を直接参照するため condition_group には依存しない。condition_group 不一致は別途修正が必要だが、トレカ出品ブロックの緊急度よりも低い。  
+**管理**: issue #47 として登録予定
+
+### E2-2: conditions_json に無効な ConditionID 3000 が含まれる問題
+
+**問題**: Sell Metadata API が依然として ConditionID 3000 を有効として返す
+- Trading API は 3000 を拒否する (エラー21920350)
+- 顧客が「中古」を選択して出品すると必ずエラーになる
+
+**影響範囲**:
+- 現在の error translation (Validation.gs:213-221) でエラーを日本語化して対応中
+- 根本解決ではなく対症療法の状態
+
+**将来の対応**:
+```
+known_invalid_conditions 列 (Phase 3) を category_master に追加:
+  "183454": ["3000"]  ← 3000 は Trading API で拒否される
+```
+月次同期で自動的に検知できるようにする（eBay API 不整合の自動フラグ管理）。  
+**管理**: Phase 3 課題として設計書に記録
+
+---
+
+## E3: 再発防止の網羅性確認
+
+### E3-1: is_trading_card_group() 該当カテゴリ全件リスト (EBAY_US)
+
+| category_id | category_name | conditions | 本番利用 |
+|-------------|---------------|-----------|---------|
+| 261328 | Trading Card Singles | [2750, 3000, 4000] | ✅ |
+| 183454 | CCG Individual Cards | [2750, 3000, 4000] | ✅ |
+| 183050 | Trading Card Singles | [2750, 3000, 4000] | ✅ |
+| 178089 | Category 2 | [1000, 2750, 4000] | ❌ テスト |
+| 37563 | Attributes6_Test | [2750, 4000] | ❌ テスト |
+| 37566 | Attributes8 | [2750, 3000, 4000] | ❌ テスト |
+| 37567 | Attributes9 | [2750, 3000, 4000] | ❌ テスト |
+| 37568 | Attributes10 | [2750, 3000, 4000] | ❌ テスト |
+
+**結論**: 顧客が実際に使用する本番カテゴリは 3 件（261328, 183454, 183050）。  
+テストカテゴリは検出されるが、本番出品では使用されないため実害なし。
+
+### E3-2: 今後eBayが新たにConditionDescriptors必須カテゴリを追加した場合
+
+**自動検出フロー**:
+1. Sell Metadata API が新カテゴリに 2750/4000 を返す
+2. 月次同期で `generate_csv.py` が `is_trading_card_group()` により `descriptor_type = "graded_card"` を自動設定
+3. category_master に反映 → 同期後、自動的にバリデーション対象になる
+
+**検出できないケース**:
+- eBay が新たな ConditionDescriptors タイプを追加した場合（e.g., コインのGrading）
+- この場合は `get_descriptor_type()` に新タイプを追加する必要がある
+- **対応フロー**: eBay Developer Program のアナウンスを監視し、必要時に対応
+
+**結論**: 月次同期で自動追跡できる。新カテゴリが出現しても追加コードなしで対応可能。
+
+### E3-3: Grader/Grade 入力ミスパターンの網羅性確認
+
+| パターン | 現状の対応 | PR #46後 |
+|---------|-----------|----------|
+| Grader あり + Grade なし | ❌ バリデーションエラー (ListingManager.gs:531) | 変更なし（既存で対応済み） |
+| Grade あり + Grader なし | ❌ バリデーションエラー (ListingManager.gs:534) | 変更なし（既存で対応済み） |
+| 両方空 + Card Condition も空（トレカカテゴリ） | ✅ **サイレント失敗** → PR #46 で修正 | ❌ バリデーションエラー |
+| Grade が 5.5〜10 範囲外 | ❌ `_GRADE_VALUE_MAP_` に存在しないキー → Gradeがnullに | 変更なし（将来対応） |
+| CGC を Grader に入力 | Other (2750123) として送信、警告なし | 変更なし（将来対応） |
+| 非トレカカテゴリで Grader/Grade 入力 | 無視されて通常出品 | 変更なし（仕様通り） |
+
+**PR #46 の修正範囲**: 「両方空 + Card Condition も空（トレカカテゴリ）」のサイレント失敗のみ  
+残りは別途対応検討（優先度低）
+
+---
+
+## 既知の制限事項（実装後も残る課題）
+
+| 制限 | 内容 | 対応方針 |
+|------|------|---------|
+| Grade は 5.5〜10 のみ対応 | eBay API の `_GRADE_VALUE_MAP_` 定義による | eBay APIが追加した場合に対応 |
+| CGC は Other 扱い | eBayの公式リストに CGC が存在しない | 現状維持（Other送信で問題なし） |
+| condition_group N/O 不一致 | Condition ドロップダウンに影響の可能性 | issue #47 として別途修正 |
+| 3000 (Used) が conditions_json に残留 | Metadata API の不整合 | Phase 3: known_invalid_conditions |
+| EBAY_GB/DE/AU のトレカカテゴリ | EBAY_US のみ検証済み | 英/独/豪向け出品時に別途確認 |
+
+---
+
+## 将来の課題 (Phase 3+)
+
+```markdown
+Phase 3: known_invalid_conditions 列の追加
+  目的: Trading API で拒否されるが Metadata API が有効と返す ConditionID を管理
+  実装: category_master に known_invalid_conditions JSON 列を追加
+  対象: 183454, 261328, 183050 の ConditionID 3000
+
+Phase 4: Column auto-suggestion
+  目的: トレカカテゴリ選択時に Grader/Grade 列の追加を自動提案
+  実装: onEdit トリガーで列がなければダイアログで案内
+  前提: PR #46 のバリデーション警告が先
+```
+
+---
+
+*エビデンス作成: Claude Sonnet 4.6 / 2026-05-02*

--- a/docs/investigations/category-master-condition-descriptors-design-20260501.md
+++ b/docs/investigations/category-master-condition-descriptors-design-20260501.md
@@ -1,0 +1,420 @@
+# category_master × ConditionDescriptors 必須スペック連携 詳細設計調査
+
+**調査日**: 2026-05-02  
+**調査対象リポジトリ**: bay-auto (~/ebay-gas-automation)  
+**背景PR**: #45 (ConditionDescriptors実装 - パターンB: 手動列管理方式)  
+**目的**: category_master を参照してカテゴリ選択だけで必要スペックを自動判定する設計案の策定
+
+---
+
+## Task 1: 現在の category_master 構造
+
+### 1-1. 列構造
+
+`category_master_EBAY_XX.csv` は現在 **15列**:
+
+| # | 列名 | 型 | 内容 |
+|---|------|----|------|
+| 1 | `marketplace_id` | string | EBAY_US / EBAY_GB / EBAY_DE / EBAY_AU |
+| 2 | `category_tree_id` | int | 0/3/77/15 |
+| 3 | `category_id` | string | eBayカテゴリID |
+| 4 | `category_name` | string | カテゴリ名 |
+| 5 | `required_specs_json` | JSON array | 必須スペック名リスト |
+| 6 | `recommended_specs_json` | JSON array | 推奨スペック名リスト |
+| 7 | `optional_specs_json` | JSON array | 任意スペック名リスト |
+| 8 | `aspect_values_json` | JSON object | スペックの選択肢一覧 |
+| 9 | `aspect_modes_json` | JSON object | スペックのモード (FREE_TEXT / SELECTION_ONLY) |
+| 10 | `multi_value_aspects_json` | JSON array | 複数選択可スペック名リスト |
+| 11 | `conditions_json` | JSON array | 有効なConditionオブジェクト一覧 |
+| 12 | `condition_group` | string | A-Z のグループラベル |
+| 13 | `fvf_rate` | float | 最終落札手数料率 |
+| 14 | `fvf_note` | string | 手数料注記 |
+| 15 | `last_synced` | date | 最終同期日 |
+
+**重要**: `conditions_json` の各オブジェクト形式は `{"id": "2750", "name": "Graded", "enum": "", "category_display": "Graded"}`.
+
+### 1-2. カテゴリ 183454 (CCG Individual Cards) の実データ
+
+```
+marketplace_id : EBAY_US
+category_id    : 183454
+category_name  : CCG Individual Cards
+required_specs_json    : ["Game"]
+recommended_specs_json : ["Card Name", "Character", "Grade", "Age Level", "Card Type",
+                          "Speciality", "Set", "Rarity", "Features", "Language",
+                          "Manufacturer", "Finish", "Graded", "Card Condition",
+                          "Professional Grader", "Certification Number", ...]
+conditions_json: [
+  {"id": "2750", "name": "Graded",   "category_display": "Graded"},
+  {"id": "3000", "name": "Used",     "category_display": "Used"},
+  {"id": "4000", "name": "Ungraded", "category_display": "Ungraded"}
+]
+condition_group: N  ← 後述の注意点参照
+fvf_rate       : (空)
+last_synced    : 2026-05-01
+```
+
+**観察**: `recommended_specs_json` に "Grade", "Graded", "Card Condition", "Professional Grader" が含まれているが、これは Item Specifics (Taxonomy API) の情報であり、ConditionDescriptors (Trading API) とは別物。
+
+### 1-3. ConditionDescriptors に関する情報
+
+現在の category_master には **ConditionDescriptors に関する列は存在しない**。  
+ただし `conditions_json` に ConditionID 2750 (Graded) または 4000 (Ungraded) が含まれているかを見ることで、  
+ConditionDescriptors が必要なカテゴリかどうかを**既存データのみで判定できる**。
+
+### 1-4. condition_group の注意点 (不一致)
+
+| データソース | カテゴリ183454のグループ | [2750, 3000, 4000] セットのラベル |
+|---|---|---|
+| category_master CSV (generate_csv.py 動的生成) | N | N |
+| condition_ja_map (SyncCategoryMaster.gs ハードコード) | O | O |
+
+**不一致が存在する**: CSVのcondition_group "N" とcondition_ja_mapの "O" が同じ条件セットを表している。  
+`generate_csv.py` はカテゴリ出現順で A/B/C... を割り当てるため、月次同期のたびに変わりうる。  
+`SyncCategoryMaster.gs` の `importConditionJaMap()` は2026-04-10時点のスナップショットをハードコードしている。  
+この不一致は既存の設計課題として別途対応が必要だが、本調査のスコープ外とする。
+
+### 1-5. トレカ系グループ判定ロジック
+
+`generate_csv.py` に既存の `is_trading_card_group()` 関数:
+
+```python
+def is_trading_card_group(ids: frozenset) -> bool:
+    return (
+        {"2750", "4000"}.issubset(ids)
+        and not ids.intersection({"5000", "6000", "7000", "2500"})
+    )
+```
+
+つまり「2750 と 4000 を両方含み、かつ消耗品的コンディションを含まない」= トレカ系カテゴリ。  
+**このロジックは追加APIコール不要で、既存 conditions_json から完全に導出できる。**
+
+---
+
+## Task 2: eBay API で取得可能な ConditionDescriptors 仕様情報
+
+### 2-1. GetCategoryFeatures
+
+- **ステータス**: **deprecated** (docs/investigations/ebay-condition-error-21920350-investigation-20260501.md に記載)
+- **現状**: 調査ドキュメント内のテスト関数として存在するのみ。本番コードには未使用。
+- **FeatureID**: ConditionValues, ConditionDescriptorInfo を指定すれば ConditionDescriptors 対応情報を取得できるが、deprecated API の使用は推奨しない。
+
+### 2-2. 現行の月次同期 API
+
+| API | 用途 | ConditionDescriptors情報 |
+|-----|------|--------------------------|
+| Taxonomy API (`fetch_item_aspects`) | required/recommended/optional スペック | なし |
+| Sell Metadata API (`getItemConditionPolicies`) | conditions_json | ConditionID のみ (Descriptorsメタなし) |
+
+**結論**: 月次同期で利用する既存 API からは ConditionDescriptors の詳細仕様（有効なGrader/Grade値ID等）は取得できない。  
+ただし「そのカテゴリでConditionDescriptorsが必要かどうか」は conditions_json から判定可能。
+
+### 2-3. GetCategorySpecifics
+
+- Item Specifics に関する情報を返すが、ConditionDescriptors とは異なる概念（Item Specifics は Taxonomy API 経由で取得済み）。
+- ConditionDescriptors の仕様情報は含まれない。
+
+### 2-4. まとめ
+
+ConditionDescriptors の **有効な Grader/Grade の ValueID マッピング** (e.g., PSA→275010, 10点→275020) は eBay API から動的取得できず、ハードコードが必要（現状の実装通り）。  
+**「このカテゴリでConditionDescriptorsが必要か」** という判定のみが今回の設計対象であり、これは既存データで導出可能。
+
+---
+
+## Task 3: 設計オプション評価
+
+### オプション1: category_master に ConditionDescriptors 情報を追加
+
+**追加列案**:
+
+| 列名 | 型 | 内容 | 自動導出可否 |
+|------|----|------|-------------|
+| `requires_condition_descriptors` | boolean | TRUE/FALSE | ✅ conditions_json から導出可 |
+| `descriptor_type` | string | `graded_card` / `none` | ✅ is_trading_card_group() で判定 |
+
+**自動導出ロジック** (generate_csv.py に追加するだけ):
+```python
+def get_descriptor_type(ids: frozenset) -> str:
+    if is_trading_card_group(ids):
+        return "graded_card"
+    return "none"
+```
+
+**評価**:
+
+| 観点 | 評価 |
+|------|------|
+| 追加APIコール | なし (既存データから導出) |
+| 月次同期への組み込み | ✅ generate_csv.py に数行追加するだけ |
+| ebay-db スキーマ変更コスト | 小 (CSV列追加のみ、GAS側でヘッダー参照するだけ) |
+| 将来の他カテゴリ拡張性 | ✅ 高 (新カテゴリが2750/4000を持てば自動検出) |
+| condition_group不一致問題との関係 | 独立 (conditions_json直接参照のため影響なし) |
+| 実装コスト | 小 |
+
+**グループX, Z も対象**:  
+SyncCategoryMaster.gs の条件グループ確認により、他にも ConditionDescriptors 対象グループが存在:
+- グループ O: [2750, 3000, 4000] → トレカ系 (183454など) ← **メイン対象**
+- グループ X: [1000, 2750, 4000] → トレカ+新品あり (is_trading_card_group判定: FALSE ← 5000/6000/7000不含かつ2750/4000含む → TRUE)
+- グループ Z: [2750, 4000] → トレカのみ
+- グループ E: [1000, 1500, 1750, 2500, 2750, 3000, 4000, 5000, 6000, 7000] → 混在 (is_trading_card_group: FALSE ← 5000/6000/7000含む)
+
+**注**: グループ X ([1000, 2750, 4000]) と グループ Z ([2750, 4000]) は `is_trading_card_group()` の定義上 TRUE になる（5000/6000/7000/2500なし、2750/4000あり）。これら少数カテゴリも自動的に対象になる。
+
+---
+
+### オプション2: ハードコードリストで対応
+
+```javascript
+const GRADED_CARD_CATEGORIES = ['183454', '261328', '183050', ...];
+```
+
+**評価**:
+
+| 観点 | 評価 |
+|------|------|
+| 実装コスト | 最小 |
+| カテゴリ追加時 | ❌ コード変更が必要 |
+| ebay-db との整合性 | ❌ なし |
+| 将来の他カテゴリ拡張性 | ❌ 低 |
+| category_master 設計思想との整合性 | ❌ 外れる |
+
+カテゴリ183454以外のトレカ系カテゴリが将来増えた際に、コード変更漏れのリスクがある。
+
+---
+
+### オプション3: 出品時に GetCategoryFeatures を動的呼び出し
+
+**評価**:
+
+| 観点 | 評価 |
+|------|------|
+| 最新仕様への追従 | ✅ |
+| API状態 | ❌ deprecated |
+| 毎出品時のAPIコール増加 | ❌ レート制限リスク |
+| 実装コスト | 大 |
+
+**採用しない理由**: GetCategoryFeatures は deprecated かつ毎出品時の API コールは運用リスクが高い。
+
+---
+
+## Task 4: 出品シートへの「動的要求」の実現方法
+
+### 現状の列読み取り方式 (PR #45 パターンB)
+
+`ListingManager.gs` の `getValueByHeader()` がヘッダー名で動的に列を参照:
+```javascript
+grader:        getValueByHeader(rowData, headerMapping, 'Grader'),
+gradeValue:    getValueByHeader(rowData, headerMapping, 'Grade'),
+certNo:        getValueByHeader(rowData, headerMapping, 'Cert No'),
+cardCondition: getValueByHeader(rowData, headerMapping, 'Card Condition'),
+```
+
+列が存在しない場合は空文字が返るだけで、エラーにはならない。
+
+### 実現方法の評価
+
+#### 方法A: バリデーション警告 (推奨)
+
+出品実行時に category_master を参照し、`requires_condition_descriptors = TRUE` のカテゴリで  
+Grader/Grade または Card Condition が未入力の場合に警告を出す。
+
+**実装箇所**: `Validation.gs`
+```javascript
+// 既存バリデーションに追加
+if (categoryMaster.descriptor_type === 'graded_card') {
+  var hasGrader = data.grader && String(data.grader).trim() !== '';
+  var hasGrade  = data.gradeValue && String(data.gradeValue).trim() !== '';
+  var hasCardCond = data.cardCondition && String(data.cardCondition).trim() !== '';
+  if (!hasGrader && !hasGrade && !hasCardCond) {
+    errors.push(
+      'カテゴリ ' + data.categoryId + ' はトレカ系です。' +
+      'Grader+Grade（鑑定済み）またはCard Condition（未鑑定）を入力してください'
+    );
+  }
+}
+```
+
+**評価**:
+- 実装シンプル
+- 既存の Validation.gs 拡張で対応可能
+- 出品実行後にユーザーが気づく (事前案内は不要な場合が多い)
+- PR #45 の実装に最小限の追加で済む
+
+#### 方法B: 列の自動追加 (将来対応)
+
+カテゴリ入力後に `onEdit` トリガーで Grader/Grade 列を自動追加。  
+UX最良だが実装複雑かつ既存データとの整合性リスクあり。  
+現時点では実装コスト対効果が低いため後回し。
+
+#### 方法C: ガイドシート参照
+
+実装最小だが顧客が自分で確認する必要あり。UX的に劣る。
+
+**推奨**: 方法A (バリデーション警告) で初期実装、方法B は将来の UX 改善フェーズで検討。
+
+---
+
+## Task 5: 既存 ebay-db 設計との整合性
+
+### 5-1. 既存2シート構造との整合性
+
+現在の ebay-db シート構造:
+```
+ebay-db (スプレッドシート)
+├── category_master_EBAY_US  (15列)
+├── category_master_EBAY_GB
+├── category_master_EBAY_DE
+├── category_master_EBAY_AU
+├── category_master_EBAY_JP  (予定)
+└── condition_ja_map
+```
+
+オプション1の場合、新シートは不要。  
+`category_master_EBAY_XX.csv` に2列追加するだけで既存構造を維持できる。
+
+### 5-2. 月次同期フローへの組み込み
+
+```
+現状フロー:
+  fetch_category_master.py → fetch_conditions.py → generate_csv.py → CSV commit
+                                                         ↑
+                                              ここに2列追加ロジックを組み込む
+```
+
+`generate_csv.py` の `build_condition_groups()` 関数内で `descriptor_type` を計算し、  
+`category_master` の各行に追加するだけ。既存の月次 cron フローで自動更新される。
+
+### 5-3. known_invalid_conditions (Phase 3候補) との統合可能性
+
+調査ドキュメント `ebay-condition-error-21920350-investigation-20260501.md` で言及されている  
+「ConditionID 3000 がトレカカテゴリで無効になっている問題」:
+
+もし `known_invalid_conditions` テーブルを将来追加する場合、  
+`descriptor_type = graded_card` のカテゴリに対して ConditionID 3000 (Used) を無効フラグとして管理できる。  
+今回の `requires_condition_descriptors` 設計はこの Phase 3 設計とも整合する。
+
+---
+
+## Task 6: 推奨設計
+
+### 推奨設計
+
+**採用オプション**: **オプション1 (category_master に `descriptor_type` 列を追加)**
+
+**理由**:  
+追加 API コール不要で既存 `conditions_json` から自動導出可能。  
+月次同期フローへの追加コストが最小（generate_csv.py に数行）。  
+category_master を「カテゴリ情報の一元管理」とする既存設計思想に合致する。  
+新カテゴリが ConditionDescriptors 対応になった場合も自動的に検出できる。
+
+---
+
+### category_master スキーマ変更案
+
+**追加列**: 1列のみ (最小構成)
+
+```
+列16: descriptor_type  (string)
+  値: "graded_card" | "none"
+```
+
+`requires_condition_descriptors` は `descriptor_type != "none"` と等価なため別列不要。  
+将来 `graded_coin` 等の新タイプが生まれた場合は値を追加するだけ。
+
+**導出ロジック** (generate_csv.py):
+```python
+def get_descriptor_type(ids: frozenset) -> str:
+    """conditions_json の id セットから ConditionDescriptors タイプを判定"""
+    if is_trading_card_group(ids):
+        return "graded_card"
+    return "none"
+```
+
+`generate_csv.py` の行生成部分 (~line 256付近) に:
+```python
+"descriptor_type": get_descriptor_type(ids),
+```
+を追加し、ヘッダー定義にも `"descriptor_type"` を追加。
+
+---
+
+### 出品シートへの動的要求方法
+
+**方針**: バリデーション警告方式 (Validation.gs 拡張)
+
+`Validation.gs` の `validateListingData()` 関数に category_master 参照を追加:
+
+1. カテゴリIDから category_master の `descriptor_type` を参照
+2. `descriptor_type === "graded_card"` の場合:
+   - Grader+Grade (鑑定済み) が両方入力済み → OK
+   - Card Condition (未鑑定) が入力済み → OK
+   - いずれも空 → 警告エラー (出品ブロック)
+
+**注意**: 現状のバリデーションは「Graderあり+Gradeなし」等の不整合チェックのみ。  
+今回は「カテゴリがトレカ系なのにどちらも空」の場合のチェックを追加。
+
+---
+
+### 実装コスト概算
+
+| 作業 | 内容 | コスト |
+|------|------|--------|
+| generate_csv.py 変更 | `descriptor_type` 列追加 (~10行) | 0.5日 |
+| SyncCategoryMaster.gs 更新 | ヘッダー定義に列名追加 | 0.5日 |
+| ImportSync.gs 更新 | 整合性チェックへの影響確認 | 0.5日 |
+| Validation.gs 変更 | category_master参照 + バリデーション追加 (~30行) | 1日 |
+| テスト (手動) | 183454で Grader/Grade 空での警告確認 | 0.5日 |
+| **合計** | | **3日** |
+
+---
+
+### 既存 PR #45 との関係
+
+**PR #45 は修正しない。新 PR を立てる。**
+
+PR #45 は「ConditionDescriptors を XML に組み込む機能」として完結している。  
+今回の変更は「ConditionDescriptors が必要なカテゴリでバリデーションを強化する」機能追加であり、  
+別の責務として分離すべき。
+
+```
+PR #45 (マージ済み): ConditionDescriptors XML 生成
+PR #46 (新規):       category_master 拡張 + バリデーション強化
+```
+
+---
+
+### 移行コスト
+
+| 項目 | 内容 |
+|------|------|
+| 既存顧客シートへの影響 | なし (既存列の追加・変更なし) |
+| Grader/Grade 列の扱い | 変更なし (引き続き任意列) |
+| 手動列追加が不要になるタイミング | 方法B (列の自動追加) 実装時 |
+| 月次同期後の自動反映 | generate_csv.py 変更後の次回同期から有効 |
+| 下位互換性 | `descriptor_type = "none"` で既存カテゴリは変化なし |
+
+---
+
+## 補足: 実装のための具体的なファイルパス
+
+| ファイル | 変更内容 |
+|----------|----------|
+| `ebay-db/scripts/generate_csv.py` | `get_descriptor_type()` 追加・行生成に descriptor_type 列追加 |
+| `gas/ebay-db/container/SyncCategoryMaster.gs` | SYNC_SHEET_NAMES は変更不要、ヘッダー定義の更新も不要 (動的転記のため) |
+| `gas/ebay-db/container/ImportSync.gs` | 整合性チェックへの影響確認 (おそらく変更不要) |
+| `gas/listing/standalone/Validation.gs` | validateListingData() にカテゴリ参照バリデーション追加 |
+| `gas/listing/standalone/ListingManager.gs` | 変更不要 (既存のGrader/Grade読み取りロジックはそのまま) |
+
+---
+
+## 決定のための選択肢まとめ
+
+| 判断 | 内容 | コスト | 推奨度 |
+|------|------|--------|--------|
+| **オプション1 採用** (推奨) | category_master に `descriptor_type` 追加 + Validation.gs 強化 | 3日 | ⭐⭐⭐ |
+| オプション2 採用 | GRADED_CARD_CATEGORIES ハードコードリスト | 0.5日 | ⭐⭐ |
+| 今は見送り | PR #45 のまま運用 (手動管理継続) | 0日 | ⭐ |
+
+---
+
+*調査実施: Claude Sonnet 4.6 / 2026-05-02*

--- a/ebay-db/scripts/generate_csv.py
+++ b/ebay-db/scripts/generate_csv.py
@@ -6,8 +6,14 @@ category_master_EBAY_XX.csv と condition_ja_map.csv を生成
 condition_group 設計:
   全カテゴリ・全マーケットの conditions_json を分析し、
   同一の condition_id セットを持つカテゴリを同じグループ（A/B/C...）に分類。
-  - category_master_EBAY_XX.csv に condition_group 列を追加（15列）
+  - category_master_EBAY_XX.csv に condition_group 列を追加（16列）
   - condition_ja_map.csv を 1グループ1行の構造に変更（6列）
+
+descriptor_type 設計 (PR #46):
+  conditions_json に ConditionID 2750 と 4000 を含み、
+  かつ 5000/6000/7000/2500 を含まないカテゴリを "graded_card" と判定。
+  → eBay Trading Card Singles / CCG Individual Cards 等。
+  出品バリデーション時に Grader/Grade または Card Condition の入力を必須化する。
 """
 
 import os
@@ -85,6 +91,26 @@ def is_trading_card_group(ids: frozenset) -> bool:
         {"2750", "4000"}.issubset(ids)
         and not ids.intersection({"5000", "6000", "7000", "2500"})
     )
+
+
+def get_descriptor_type(ids: frozenset) -> str:
+    """conditions_json の id セットから ConditionDescriptors タイプを判定する。
+
+    判定ロジック (is_trading_card_group() を再利用):
+    - 2750 (Graded) AND 4000 (Ungraded) を含む
+    - かつ 5000/6000/7000/2500 を含まない
+    → "graded_card"
+
+    それ以外 → "none"
+
+    根拠: docs/evidence/pr46-evidence.md E1-3, E1-4
+    公式: developer.ebay.com/api-docs/user-guides/static/mip-user-guide/
+          mip-enum-condition-descriptor-ids-for-trading-cards.html
+    対象カテゴリ: 183454 (CCG Individual Cards), 261328/183050 (Trading Card Singles)
+    """
+    if is_trading_card_group(ids):
+        return "graded_card"
+    return "none"
 
 
 def is_apparel_group(ids: frozenset) -> bool:
@@ -202,18 +228,20 @@ def build_condition_groups(
 def generate_category_master(
     rows: list[dict], fvf_rates: dict, row_group_labels: list[str]
 ) -> None:
-    """マーケットプレイスごとに category_master_EBAY_XX.csv を生成（15列）
+    """マーケットプレイスごとに category_master_EBAY_XX.csv を生成（16列）
 
     列定義: marketplace_id, category_tree_id, category_id, category_name,
             required_specs_json, recommended_specs_json, optional_specs_json,
             aspect_values_json, aspect_modes_json, multi_value_aspects_json,
-            conditions_json, condition_group, fvf_rate, fvf_note, last_synced
+            conditions_json, condition_group, fvf_rate, fvf_note, last_synced,
+            descriptor_type
     """
     fieldnames = [
         "marketplace_id", "category_tree_id", "category_id", "category_name",
         "required_specs_json", "recommended_specs_json", "optional_specs_json",
         "aspect_values_json", "aspect_modes_json", "multi_value_aspects_json",
         "conditions_json", "condition_group", "fvf_rate", "fvf_note", "last_synced",
+        "descriptor_type",  # 列16: ConditionDescriptors タイプ (PR #46)
     ]
 
     # マーケットプレイスごとに分類（行インデックスを保持）
@@ -242,6 +270,16 @@ def generate_category_master(
                         fvf_note = info.get("fvf_note", "")
                         break
 
+                # descriptor_type: conditions_json から ConditionDescriptors タイプを判定
+                try:
+                    cond_ids = frozenset(
+                        str(c["id"])
+                        for c in json.loads(row.get("conditions_json", "[]") or "[]")
+                        if isinstance(c, dict) and "id" in c
+                    )
+                except Exception:
+                    cond_ids = frozenset()
+
                 writer.writerow({
                     "marketplace_id":           mp,
                     "category_tree_id":         row.get("category_tree_id", ""),
@@ -258,12 +296,13 @@ def generate_category_master(
                     "fvf_rate":                 fvf_rate,
                     "fvf_note":                 fvf_note,
                     "last_synced":              TODAY,
+                    "descriptor_type":          get_descriptor_type(cond_ids),
                 })
 
         print(f"  {output_path}: {len(indexed_rows)} 行")
         total += len(indexed_rows)
 
-    print(f"category_master_EBAY_*.csv 生成完了: 合計 {total} 行（condition_group列追加）")
+    print(f"category_master_EBAY_*.csv 生成完了: 合計 {total} 行（condition_group + descriptor_type列追加）")
 
 
 def generate_condition_ja_map(group_registry: dict[frozenset, dict]) -> None:

--- a/gas/ebay-db/container/ImportSync.gs
+++ b/gas/ebay-db/container/ImportSync.gs
@@ -716,7 +716,8 @@ function setupHeaders() {
     'marketplace_id', 'category_tree_id', 'category_id', 'category_name',
     'required_specs_json', 'recommended_specs_json', 'optional_specs_json',
     'aspect_values_json', 'aspect_modes_json', 'multi_value_aspects_json',
-    'conditions_json', 'condition_group', 'fvf_rate', 'fvf_note', 'last_synced'
+    'conditions_json', 'condition_group', 'fvf_rate', 'fvf_note', 'last_synced',
+    'descriptor_type'  // 列16: ConditionDescriptors タイプ (PR #46)
   ];
 
   // 新スキーマ: 1グループ1行
@@ -764,7 +765,8 @@ function setupHeadersUS() {
     'marketplace_id', 'category_tree_id', 'category_id', 'category_name',
     'required_specs_json', 'recommended_specs_json', 'optional_specs_json',
     'aspect_values_json', 'aspect_modes_json', 'multi_value_aspects_json',
-    'conditions_json', 'condition_group', 'fvf_rate', 'fvf_note', 'last_synced'
+    'conditions_json', 'condition_group', 'fvf_rate', 'fvf_note', 'last_synced',
+    'descriptor_type'  // 列16: ConditionDescriptors タイプ (PR #46)
   ];
 
   var name  = 'category_master_EBAY_US';

--- a/gas/listing/standalone/ListingManager.gs
+++ b/gas/listing/standalone/ListingManager.gs
@@ -552,18 +552,34 @@ function validateListingData(data) {
     }
   }
 
-  // Brand必須チェック（カテゴリ依存）
+  // カテゴリマスタ参照チェック（Brand必須 + ConditionDescriptors必須）
   // ※ validateListingDataにspreadsheetIdが渡っていない場合は
   //   CURRENT_SPREADSHEET_IDを使用
   try {
     var catData = getCategoryMasterDataForListing(CURRENT_SPREADSHEET_ID, String(data.categoryId));
+
+    // Brand必須チェック
     if (catData && catData.requiredSpecs && catData.requiredSpecs.indexOf('Brand') !== -1) {
       if (!data.brand || String(data.brand).trim() === '') {
         errors.push('Brand（ブランド）が未入力です → Brand列に入力してください');
       }
     }
-  } catch(brandCheckErr) {
-    Logger.log('Brand必須チェックエラー（続行）: ' + brandCheckErr.toString());
+
+    // ConditionDescriptors 必須チェック (PR #46)
+    // descriptor_type = "graded_card" のカテゴリでは
+    // Grader+Grade（鑑定済み）または Card Condition（未鑑定）のいずれかが必須
+    if (catData && catData.descriptorType === 'graded_card') {
+      var hasCardCondition = data.cardCondition && String(data.cardCondition).trim() !== '';
+      if (!hasGrader && !hasGradeValue && !hasCardCondition) {
+        errors.push(
+          'トレカカテゴリ（カテゴリID: ' + String(data.categoryId) + '）の出品には以下のいずれかの入力が必要です:\n' +
+          '  ・鑑定済み: Grader列（PSA / BGS / SGC 等）+ Grade列（10 / 9.5 / 9 等）\n' +
+          '  ・未鑑定: Card Condition列（Near Mint or Better / Excellent / Very Good / Poor）'
+        );
+      }
+    }
+  } catch(catCheckErr) {
+    Logger.log('カテゴリマスタチェックエラー（続行）: ' + catCheckErr.toString());
   }
 
   return errors;
@@ -3227,13 +3243,14 @@ function getCategoryMasterDataForListing(spreadsheetId, categoryId) {
     const headers = data[0];
 
     const idx = {
-      catId:   headers.indexOf('category_id'),
-      catName: headers.indexOf('category_name'),
-      req:     headers.indexOf('required_specs_json'),
-      rec:     headers.indexOf('recommended_specs_json'),
-      opt:     headers.indexOf('optional_specs_json'),
-      aspVal:  headers.indexOf('aspect_values_json'),
-      group:   headers.indexOf('condition_group')
+      catId:    headers.indexOf('category_id'),
+      catName:  headers.indexOf('category_name'),
+      req:      headers.indexOf('required_specs_json'),
+      rec:      headers.indexOf('recommended_specs_json'),
+      opt:      headers.indexOf('optional_specs_json'),
+      aspVal:   headers.indexOf('aspect_values_json'),
+      group:    headers.indexOf('condition_group'),
+      descType: headers.indexOf('descriptor_type')  // PR #46
     };
 
     if (idx.catId === -1) {
@@ -3248,12 +3265,13 @@ function getCategoryMasterDataForListing(spreadsheetId, categoryId) {
       if (String(data[i][idx.catId]) === String(categoryId)) {
         return {
           categoryId:       String(data[i][idx.catId]),
-          categoryName:     idx.catName !== -1 ? String(data[i][idx.catName] || '') : '',
-          requiredSpecs:    idx.req    !== -1 ? parseArr(data[i][idx.req])    : [],
-          recommendedSpecs: idx.rec    !== -1 ? parseArr(data[i][idx.rec])    : [],
-          optionalSpecs:    idx.opt    !== -1 ? parseArr(data[i][idx.opt])    : [],
-          aspectValues:     idx.aspVal !== -1 ? parseObj(data[i][idx.aspVal]) : {},
-          conditionGroup:   idx.group  !== -1 ? String(data[i][idx.group] || '') : ''
+          categoryName:     idx.catName  !== -1 ? String(data[i][idx.catName]  || '') : '',
+          requiredSpecs:    idx.req      !== -1 ? parseArr(data[i][idx.req])         : [],
+          recommendedSpecs: idx.rec      !== -1 ? parseArr(data[i][idx.rec])         : [],
+          optionalSpecs:    idx.opt      !== -1 ? parseArr(data[i][idx.opt])         : [],
+          aspectValues:     idx.aspVal   !== -1 ? parseObj(data[i][idx.aspVal])      : {},
+          conditionGroup:   idx.group    !== -1 ? String(data[i][idx.group]    || '') : '',
+          descriptorType:   idx.descType !== -1 ? String(data[i][idx.descType] || 'none') : 'none'  // PR #46
         };
       }
     }


### PR DESCRIPTION
## 変更の背景

PR #45 でConditionDescriptors送信を実装したが、出品シートに Grader/Grade/Card Condition 列が存在しない場合にサイレントで空送信されてしまう問題が残っていた。

根本対策として `category_master` に `descriptor_type` 列を追加し、カテゴリ選択だけで必要なスペックが自動判定される設計に変更する。

**関連PR**: #45 (ConditionDescriptors送信実装・マージ済み)  
**エビデンス**: [`docs/evidence/pr46-evidence.md`](docs/evidence/pr46-evidence.md)  
**設計調査**: [`docs/investigations/category-master-condition-descriptors-design-20260501.md`](docs/investigations/category-master-condition-descriptors-design-20260501.md)

## 変更内容

### `ebay-db/scripts/generate_csv.py`
- `get_descriptor_type(ids: frozenset) -> str` を追加
  - conditions_json に 2750 + 4000 を含み、5000/6000/7000/2500 を含まない → `"graded_card"`
  - それ以外 → `"none"`
- `category_master_EBAY_XX.csv` に `descriptor_type` 列を追加（16列目）
- **追加APIコールなし**・月次 cron で自動更新

### `gas/listing/standalone/ListingManager.gs`
- `getCategoryMasterDataForListing()` に `descriptorType` フィールドを追加（列なし時は `'none'` にフォールバック）
- `validateListingData()` にConditionDescriptors必須チェックを追加
  - `descriptorType === 'graded_card'` かつ Grader/Grade/Card Condition が全て空 → **出品ブロック**

### `gas/ebay-db/container/ImportSync.gs`
- `setupHeaders()` / `setupHeadersUS()` の `CATEGORY_HEADERS` に `descriptor_type` を追加

## category_master スキーマ変更

```
列16（新規追加）: descriptor_type
  "graded_card" — ConditionDescriptors 必須カテゴリ（トレカ系: 183454, 261328, 183050）
  "none"        — 通常カテゴリ
```

**既存顧客への影響なし** — CSV に列が追加されるだけ。GASは `headers.indexOf()` で動的参照。

## テスト計画

- [ ] シナリオ1: 183454 + Grader=PSA + Grade=10 → 出品成功 (Graded 2750)
- [ ] シナリオ2: 183454 + Card Condition=Near Mint or Better → 出品成功 (Ungraded 4000)
- [ ] シナリオ3: 183454 + Grader=PSA + Grade=空 → 警告「Gradeが空」(既存)
- [ ] シナリオ4: 183454 + 全て空 → 警告「ConditionDescriptors必須」(**PR #46 新規**)
- [ ] シナリオ5: 183454 + CGC + Grade=10 → 出品成功 (Other扱い)
- [ ] シナリオ6: 非トレカカテゴリ + 全て空 → 従来通り出品成功 (リグレッションなし)
- [ ] シナリオ7: 非トレカカテゴリ + Grader/Grade入力 → Grader/Grade無視で通常出品

## 既知の制限事項（スコープ外）

| 課題 | 管理 |
|------|------|
| condition_group N/O ラベル不一致 | issue #47 として別途修正 |
| known_invalid_conditions (3000 問題) | Phase 3 |
| EBAY_GB/DE/AU のトレカカテゴリ未検証 | 次フェーズ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)