### PR TITLE
fix: セルスタCSV列名をPR#48以前に戻す（緊急リバート）

### DIFF
--- a/gas/listing/standalone/CsvExport.gs
+++ b/gas/listing/standalone/CsvExport.gs
@@ -10,11 +10,11 @@ const SELLSTA_CSV_HEADERS = [
   'image_url7','image_url8','image_url9','image_url10','image_url11','image_url12',
   'image_url13','image_url14','image_url15','image_url16','image_url17','image_url18',
   'image_url19','image_url20','image_url21','image_url22','image_url23','image_url24',
-  '①仕入れ先情報','②仕入れ先情報','③仕入れ先情報',
+  '①仕入先情報','②仕入先情報','③仕入先情報',
   'Custom label (SKU)','Condition','Condition description',
   'Item Code type','Item Code','CategoryID','Item Specifics',
   'ListingType','Duration','Selling Price',
-  'Best Offers (accept offers of at least)','Best Offers (decline offers lower than)',
+  'Best Offers（accept offers of at least）','Best Offers（decline offers lower than）',
   'Quantity','Store Category','Shipping Policy','Payment Policy','Return Policy',
   'Private Listing','Description','listing_date','Memo','Custom Link'
 ];


### PR DESCRIPTION
## 概要

PR #48 の変更を緊急リバート。

## 変更内容

### 修正1: 仕入先情報の列名（「れ」を削除）
- **変更前**: `①仕入れ先情報`, `②仕入れ先情報`, `③仕入れ先情報`
- **変更後**: `①仕入先情報`, `②仕入先情報`, `③仕入先情報`

### 修正2: Best Offers の括弧（半角→全角）
- **変更前**: `Best Offers (accept offers of at least)`（半角）
- **変更後**: `Best Offers（accept offers of at least）`（全角）

## 理由

セルスタの実環境でのインポート動作確認の結果、PR #48 の修正が誤りだったため緊急リバート。