### PR TITLE
ci: research standalone/bind SCRIPT_ID未設定時のスキップガード

### DIFF
--- a/.github/workflows/deploy-gas.yml
+++ b/.github/workflows/deploy-gas.yml
@@ -96,6 +96,10 @@ jobs:
           else
             SCRIPT_ID="${{ secrets.RESEARCH_SA_DEV }}"
           fi
+          if [ -z "$SCRIPT_ID" ]; then
+            echo "⚠️ SCRIPT_ID が未設定のためスキップ（RESEARCH_SA_PROD/DEV シークレットを確認してください）"
+            exit 0
+          fi
           sed -i "s/REPLACED_BY_CI/$SCRIPT_ID/" .clasp.json
           clasp push --force
 
@@ -125,6 +129,10 @@ jobs:
           else
             SCRIPT_ID="${{ secrets.RESEARCH_BIND_DEV }}"
             SA_SCRIPT_ID="${{ secrets.RESEARCH_SA_DEV }}"
+          fi
+          if [ -z "$SCRIPT_ID" ]; then
+            echo "⚠️ SCRIPT_ID が未設定のためスキップ（RESEARCH_BIND_PROD/DEV シークレットを確認してください）"
+            exit 0
           fi
           sed -i "s/REPLACED_BY_CI/$SCRIPT_ID/" .clasp.json
           sed -i "s/RESEARCH_SA_SCRIPT_ID/$SA_SCRIPT_ID/" appsscript.json


### PR DESCRIPTION
## 問題

`RESEARCH_SA_PROD` / `RESEARCH_BIND_PROD` シークレットが未設定の状態で main にマージすると
`deploy-research-standalone` / `deploy-research-bind` ジョブが `clasp push` エラーで失敗する。

## 修正

SCRIPT_ID が空文字の場合は警告メッセージを出して `exit 0`（成功扱いでスキップ）。

シークレット追加後は自動的に有効になる。