### PR TITLE
fix: Descriptionテンプレート未設定時のエラー明示化

### DIFF
--- a/docs/investigations/description-template-investigation-20260513.md
+++ b/docs/investigations/description-template-investigation-20260513.md
@@ -1,0 +1,90 @@
+# Description テンプレート「テンプレート1」調査レポート
+
+**日付:** 2026-05-13  
+**対象:** `gas/listing/standalone/ListingManager.gs` — `generateDescriptionFromTemplate`
+
+---
+
+## 現象
+
+顧客の eBay 出品に Description として「テンプレート1」がそのままテキスト表示された。  
+出品シートの Description 列には「テンプレート1」と入力されており、  
+本来はその名前で `Description_テンプレ` シートを引いた HTML が展開されるはずだった。
+
+---
+
+## コード調査結果
+
+`generateDescriptionFromTemplate()` に **5 箇所の silent fallback** が存在した。  
+いずれも `return templateName` で失敗を無音で吸収し、テンプレート名がそのまま Description に入る。
+
+| # | 条件 | 旧コード | 影響 |
+|---|------|----------|------|
+| A | `Description_テンプレ` シートが存在しない | `return templateName` | テンプレート名がそのまま出品される |
+| B | シートに 2 行目以降のデータがない | `return templateName` | 同上 |
+| C | `テンプレート名` 列ヘッダーがない | `return templateName` | 同上 |
+| D | `テンプレート` 列ヘッダーがない | `return templateName` | 同上 |
+| E | 指定テンプレート名に一致する行がない | `return templateName` | 同上（最頻出パターン） |
+
+さらに関数全体を `try/catch` で包み、catch で `return templateName` していたため、  
+上記 A〜E のいずれかで throw しても catch が吸収してしまう構造だった。
+
+### 根本原因
+
+顧客スプレッドシートで以下のいずれか（またはその組み合わせ）が未設定だった可能性が高い:
+
+- Pattern A: `Description_テンプレ` シートが作成されていない  
+- Pattern E: シートはあるが「テンプレート1」という名前の行が登録されていない
+
+いずれの場合も、コードが silent fallback によってエラーを黙殺し、  
+テンプレート名「テンプレート1」がそのままeBay APIに送信された。
+
+---
+
+## 修正内容
+
+`generateDescriptionFromTemplate()` の全 silent fallback を `throw new Error(...)` に変更。  
+try/catch を除去し、エラーが呼び出し元まで確実に伝播するようにした。
+
+### 変更箇所
+
+**`gas/listing/standalone/ListingManager.gs`**
+
+| 条件 | 変更前 | 変更後 |
+|------|--------|--------|
+| シートなし | `return templateName` | `throw new Error('"Description_テンプレ"シートが見つかりません...')` |
+| データなし | `return templateName` | `throw new Error('"Description_テンプレ"シートにデータがありません...')` |
+| テンプレート名列なし | `return templateName` | `throw new Error('...「テンプレート名」列がありません...')` |
+| テンプレート列なし | `return templateName` | `throw new Error('...「テンプレート」列がありません...')` |
+| 行マッチなし | `return templateName` | `throw new Error('...テンプレートが見つかりません。登録済み: ...')` |
+| catch block | `return templateName` | try/catch を除去（エラー伝播） |
+
+エラーメッセージには登録済みテンプレート名の一覧を含め、顧客が自己解決できるよう設計した。
+
+---
+
+## 顧客対応テキスト
+
+> 【Description テンプレート未設定について】  
+>  
+> ご指摘いただいた件を調査しました。出品シートの Description 列に「テンプレート1」と入力されていましたが、  
+> 出品シートに紐づくスプレッドシートに「Description_テンプレ」シートが存在しないか、  
+> そのシートに「テンプレート1」というテンプレートが登録されていなかったため、  
+> テンプレート名がそのまま eBay に送信されてしまいました。  
+>  
+> 【修正済み】  
+> テンプレートが見つからない場合にエラーで停止するよう修正しました。  
+> 次回以降は出品時に「テンプレートが見つかりません」というエラーが表示されます。  
+>  
+> 【ご対応いただく内容】  
+> 出品シートのスプレッドシートに「Description_テンプレ」シートを作成し、  
+> 1 行目に「テンプレート名」「テンプレート」の列を追加してください。  
+> 次に「テンプレート1」という名前の行にHTMLテンプレートを入力すると、  
+> 正常に Description が生成されます。
+
+---
+
+## 関連ファイル
+
+- `gas/listing/standalone/ListingManager.gs` — `generateDescriptionFromTemplate()` (L191〜)
+- `02_apps/ebay-listing-manager/ListingManager.gs` — 同関数（apps コピー）

--- a/gas/listing/standalone/ListingManager.gs
+++ b/gas/listing/standalone/ListingManager.gs
@@ -197,123 +197,113 @@ function extractItemSpecifics(rowData, headerMapping) {
  * @param {string} templateName テンプレート名（出品シートのDescription列の値）
  * @param {string} conditionDescription 状態説明（置換する文章）
  * @param {string} spreadsheetId スプレッドシートID
- * @returns {string} 生成されたDescription（テンプレートが見つからない場合はtemplateName をそのまま返す）
+ * @returns {string} 生成されたDescription
+ * @throws {Error} テンプレートが見つからない場合または設定に問題がある場合
  */
 function generateDescriptionFromTemplate(templateName, conditionDescription, spreadsheetId) {
-  try {
-    Logger.log('=== Description生成開始 ===');
-    Logger.log('テンプレート名: "' + templateName + '"');
-    Logger.log('状態説明: "' + (conditionDescription ? String(conditionDescription).substring(0, 50) + '...' : '(空)') + '"');
+  Logger.log('=== Description生成開始 ===');
+  Logger.log('テンプレート名: "' + templateName + '"');
+  Logger.log('状態説明: "' + (conditionDescription ? String(conditionDescription).substring(0, 50) + '...' : '(空)') + '"');
 
-    // テンプレート名が空の場合はそのまま返す
-    if (!templateName || String(templateName).trim() === '') {
-      Logger.log('⚠️ テンプレート名が空です。変換せずに返します。');
-      return templateName;
-    }
-
-    // Description_テンプレシートを取得
-    const ss = spreadsheetId
-      ? SpreadsheetApp.openById(spreadsheetId)
-      : SpreadsheetApp.getActiveSpreadsheet();
-
-    const templateSheet = ss.getSheetByName('Description_テンプレ');
-
-    if (!templateSheet) {
-      Logger.log('❌ "Description_テンプレ"シートが見つかりません。テンプレート名をそのまま返します。');
-      return templateName;
-    }
-
-    Logger.log('✅ Description_テンプレシートが見つかりました');
-
-    // ヘッダー行を取得（1行目）
-    const lastRow = templateSheet.getLastRow();
-    const lastCol = templateSheet.getLastColumn();
-
-    if (lastRow < 2) {
-      Logger.log('⚠️ Description_テンプレシートにデータがありません');
-      return templateName;
-    }
-
-    const headers = templateSheet.getRange(1, 1, 1, lastCol).getValues()[0];
-    Logger.log('ヘッダー: ' + JSON.stringify(headers));
-
-    // ヘッダーマッピングを作成
-    const headerMapping = {};
-    for (let i = 0; i < headers.length; i++) {
-      const headerName = headers[i];
-      if (headerName) {
-        headerMapping[headerName] = i + 1;
-      }
-    }
-
-    const templateNameCol = headerMapping['テンプレート名'];
-    const templateCol = headerMapping['テンプレート'];
-
-    if (!templateNameCol) {
-      Logger.log('❌ "テンプレート名"列が見つかりません');
-      return templateName;
-    }
-
-    if (!templateCol) {
-      Logger.log('❌ "テンプレート"列が見つかりません');
-      return templateName;
-    }
-
-    Logger.log('「テンプレート名」列: ' + templateNameCol);
-    Logger.log('「テンプレート」列: ' + templateCol);
-
-    // データを取得（2行目以降）
-    const data = templateSheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
-
-    // テンプレート名で検索
-    let foundTemplate = null;
-    for (let i = 0; i < data.length; i++) {
-      const name = data[i][templateNameCol - 1]; // 0-based
-      const template = data[i][templateCol - 1]; // 0-based
-
-      if (name && String(name).trim() === String(templateName).trim()) {
-        foundTemplate = template;
-        Logger.log('✅ テンプレート発見: 行' + (i + 2));
-        break;
-      }
-    }
-
-    if (!foundTemplate) {
-      Logger.log('⚠️ テンプレート名"' + templateName + '"に該当するテンプレートが見つかりません');
-      Logger.log('利用可能なテンプレート名:');
-      for (let i = 0; i < data.length; i++) {
-        const name = data[i][templateNameCol - 1];
-        if (name) {
-          Logger.log('  - "' + name + '"');
-        }
-      }
-      return templateName;
-    }
-
-    // {説明文}を置換
-    let description = String(foundTemplate);
-
-    if (conditionDescription && String(conditionDescription).trim() !== '') {
-      description = description.replace(/\{説明文\}/g, String(conditionDescription));
-      Logger.log('✅ {説明文}を置換しました');
-    } else {
-      description = description.replace(/\{説明文\}/g, '');
-      Logger.log('状態説明が空のため{説明文}を除去します');
-    }
-
-    Logger.log('生成されたDescription（最初の100文字）: ' + description.substring(0, 100) + '...');
-    Logger.log('=== Description生成完了 ===');
-
-    return description;
-
-  } catch (error) {
-    Logger.log('❌ Description生成エラー: ' + error.toString());
-    if (error.stack) {
-      Logger.log('スタックトレース: ' + error.stack);
-    }
-    // エラーが発生した場合はテンプレート名をそのまま返す
+  // テンプレート名が空の場合はそのまま返す
+  if (!templateName || String(templateName).trim() === '') {
+    Logger.log('⚠️ テンプレート名が空です。変換せずに返します。');
     return templateName;
   }
+
+  // Description_テンプレシートを取得
+  const ss = spreadsheetId
+    ? SpreadsheetApp.openById(spreadsheetId)
+    : SpreadsheetApp.getActiveSpreadsheet();
+
+  const templateSheet = ss.getSheetByName('Description_テンプレ');
+
+  if (!templateSheet) {
+    throw new Error('"Description_テンプレ"シートが見つかりません。スプレッドシートに「Description_テンプレ」シートを作成してください。');
+  }
+
+  Logger.log('✅ Description_テンプレシートが見つかりました');
+
+  // ヘッダー行を取得（1行目）
+  const lastRow = templateSheet.getLastRow();
+  const lastCol = templateSheet.getLastColumn();
+
+  if (lastRow < 2) {
+    throw new Error('"Description_テンプレ"シートにデータがありません。1行目にヘッダー、2行目以降にテンプレートを追加してください。');
+  }
+
+  const headers = templateSheet.getRange(1, 1, 1, lastCol).getValues()[0];
+  Logger.log('ヘッダー: ' + JSON.stringify(headers));
+
+  // ヘッダーマッピングを作成
+  const headerMapping = {};
+  for (let i = 0; i < headers.length; i++) {
+    const headerName = headers[i];
+    if (headerName) {
+      headerMapping[headerName] = i + 1;
+    }
+  }
+
+  const templateNameCol = headerMapping['テンプレート名'];
+  const templateCol = headerMapping['テンプレート'];
+
+  if (!templateNameCol) {
+    throw new Error('"Description_テンプレ"シートに「テンプレート名」列がありません。1行目に「テンプレート名」ヘッダーを追加してください。');
+  }
+
+  if (!templateCol) {
+    throw new Error('"Description_テンプレ"シートに「テンプレート」列がありません。1行目に「テンプレート」ヘッダーを追加してください。');
+  }
+
+  Logger.log('「テンプレート名」列: ' + templateNameCol);
+  Logger.log('「テンプレート」列: ' + templateCol);
+
+  // データを取得（2行目以降）
+  const data = templateSheet.getRange(2, 1, lastRow - 1, lastCol).getValues();
+
+  // テンプレート名で検索
+  let foundTemplate = null;
+  for (let i = 0; i < data.length; i++) {
+    const name = data[i][templateNameCol - 1]; // 0-based
+    const template = data[i][templateCol - 1]; // 0-based
+
+    if (name && String(name).trim() === String(templateName).trim()) {
+      foundTemplate = template;
+      Logger.log('✅ テンプレート発見: 行' + (i + 2));
+      break;
+    }
+  }
+
+  if (!foundTemplate) {
+    const availableNames = [];
+    for (let i = 0; i < data.length; i++) {
+      const name = data[i][templateNameCol - 1];
+      if (name) availableNames.push(String(name).trim());
+    }
+    throw new Error(
+      'Descriptionテンプレート「' + templateName + '」が Description_テンプレシートに見つかりません。' +
+      'シートに「テンプレート名」列と一致する行を追加してください。' +
+      (availableNames.length > 0
+        ? '（登録済みテンプレート名: ' + availableNames.join(', ') + '）'
+        : '（テンプレートが1件も登録されていません）')
+    );
+  }
+
+  // {説明文}を置換
+  let description = String(foundTemplate);
+
+  if (conditionDescription && String(conditionDescription).trim() !== '') {
+    description = description.replace(/\{説明文\}/g, String(conditionDescription));
+    Logger.log('✅ {説明文}を置換しました');
+  } else {
+    description = description.replace(/\{説明文\}/g, '');
+    Logger.log('状態説明が空のため{説明文}を除去します');
+  }
+
+  Logger.log('生成されたDescription（最初の100文字）: ' + description.substring(0, 100) + '...');
+  Logger.log('=== Description生成完了 ===');
+
+  return description;
 }
 
 /**


### PR DESCRIPTION
## 概要

`generateDescriptionFromTemplate()` の silent fallback を全て `throw new Error()` に変更。

**現象:** 顧客の eBay 出品 Description フィールドに「テンプレート1」がそのまま表示された。

**根本原因:** `Description_テンプレ` シートが未設定または「テンプレート1」行が未登録の場合、
コードが `return templateName` で黙殺し、テンプレート名をそのまま eBay API に送信していた。
さらに `try/catch` が全体を包んでいたため、throw しても catch で吸収される構造だった。

## 変更内容

`gas/listing/standalone/ListingManager.gs` — `generateDescriptionFromTemplate()`

| 条件 | 変更前 | 変更後 |
|------|--------|--------|
| `Description_テンプレ` シートなし | `return templateName` | `throw new Error(...)` |
| シートにデータなし | `return templateName` | `throw new Error(...)` |
| `テンプレート名` 列なし | `return templateName` | `throw new Error(...)` |
| `テンプレート` 列なし | `return templateName` | `throw new Error(...)` |
| 指定名の行が見つからない | `return templateName` | `throw new Error(登録済み名一覧付き)` |
| catch block | `return templateName` | try/catch を除去（エラー伝播） |

エラーメッセージには登録済みテンプレート名の一覧を含め、顧客が自己解決できるよう設計。

調査レポート: `docs/investigations/description-template-investigation-20260513.md`

## テスト計画

- [ ] `Description_テンプレ` シートなしで出品 → エラーメッセージが表示されること
- [ ] シートはあるが該当テンプレート名なし → エラーに登録済み名一覧が含まれること
- [ ] 正常ケース（シート・行あり）→ Description が生成されること