### PR TITLE
feat: ブック間自動双方向同期 (Phase 1+2)

### DIFF
--- a/.github/workflows/deploy-gas.yml
+++ b/.github/workflows/deploy-gas.yml
@@ -12,6 +12,7 @@ on:
       - 'gas/research/container/**'
       - 'gas/research/bind/**'
       - 'gas/ebay-db/container/**'
+      - 'gas/ebay-db/bind/**'
 
 jobs:
   deploy-listing-standalone:
@@ -164,6 +165,41 @@ jobs:
             SCRIPT_ID="${{ secrets.RESEARCH_CB_DEV }}"
           fi
           sed -i "s/REPLACED_BY_CI/$SCRIPT_ID/" .clasp.json
+          clasp push --force
+
+  deploy-ebay-db-bind:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install clasp
+        run: npm install -g @google/clasp
+
+      - name: Restore clasp credentials
+        run: echo '${{ secrets.CLASPRC_JSON }}' > ~/.clasprc.json
+
+      - name: Set scriptId and deploy
+        run: |
+          cd gas/ebay-db/bind
+          if [ "${{ github.ref_name }}" = "main" ]; then
+            SCRIPT_ID="${{ secrets.EBAY_DB_BIND_PROD }}"
+            SA_SCRIPT_ID="${{ secrets.LISTING_SA_PROD }}"
+          else
+            SCRIPT_ID="${{ secrets.EBAY_DB_BIND_DEV }}"
+            SA_SCRIPT_ID="${{ secrets.LISTING_SA_DEV }}"
+          fi
+          if [ -z "$SCRIPT_ID" ]; then
+            echo "⚠️ SCRIPT_ID が未設定のためスキップ（EBAY_DB_BIND_PROD/DEV シークレットを確認してください）"
+            exit 0
+          fi
+          sed -i "s/REPLACED_BY_CI/$SCRIPT_ID/" .clasp.json
+          sed -i "s/LISTING_SA_SCRIPT_ID/$SA_SCRIPT_ID/" appsscript.json
           clasp push --force
 
   deploy-ebay-db-container:

--- a/gas/ebay-db/bind/.clasp.json
+++ b/gas/ebay-db/bind/.clasp.json
@@ -1,0 +1,1 @@
+{ "scriptId": "REPLACED_BY_CI", "rootDir": "." }

--- a/gas/ebay-db/bind/Code.gs
+++ b/gas/ebay-db/bind/Code.gs
@@ -1,0 +1,74 @@
+/**
+ * eBay出品DB - バインドスクリプト（自動同期用）
+ *
+ * 出品DBスプレッドシートに設置するバインドスクリプト。
+ * 設定系シートの変更を検知して出品シートに自動同期する (db → ss)。
+ *
+ * セットアップ手順:
+ * 1. 出品DBスプレッドシートで「拡張機能」→「Apps Script」を開く
+ * 2. このコードを貼り付け
+ * 3. ライブラリ: EbayLib を追加（scriptID はツール設定 B18）、識別子 EbayLib
+ * 4. 保存 → 「eBay出品DB」→「権限承認・トリガー登録」を実行
+ */
+
+// 自動同期対象シート（設定系シートのみ）
+const SYNC_TARGET_SHEETS_DB = [
+  'プルダウン管理', 'ツール設定', '状態_テンプレ',
+  'Description_テンプレ', '担当者管理', '報酬管理', 'ポリシー管理'
+];
+
+/**
+ * スプレッドシートを開いたときにカスタムメニューを追加
+ */
+function onOpen() {
+  SpreadsheetApp.getUi()
+    .createMenu('⚙️ 出品DB')
+    .addItem('権限承認・トリガー登録', 'authorizeDBScript')
+    .addToUi();
+}
+
+/**
+ * 出品DB側の onEdit トリガー
+ * 設定系シートの変更を検知して出品シートに自動同期 (db → ss)
+ *
+ * @param {GoogleAppsScript.Events.SheetsOnEdit} e
+ */
+function handleEditDB(e) {
+  if (!e || !e.range) return;
+  var sheetName = e.range.getSheet().getName();
+  if (SYNC_TARGET_SHEETS_DB.indexOf(sheetName) === -1) return;
+
+  try {
+    var result = EbayLib.autoSyncDBToSheet(e.source.getId(), sheetName);
+    if (result && !result.success) {
+      Logger.log('⚠️ 自動同期スキップ（' + sheetName + '）: ' + result.message);
+    }
+  } catch (err) {
+    Logger.log('handleEditDB エラー（継続）: ' + err.toString());
+  }
+}
+
+/**
+ * 権限承認 & installable onEdit トリガー登録
+ * 初回セットアップ時に手動で実行する
+ */
+function authorizeDBScript() {
+  // 既存の handleEditDB トリガーを削除（重複登録防止）
+  ScriptApp.getProjectTriggers().forEach(function(t) {
+    if (t.getHandlerFunction() === 'handleEditDB') {
+      ScriptApp.deleteTrigger(t);
+    }
+  });
+
+  // installable onEdit トリガーを登録
+  ScriptApp.newTrigger('handleEditDB')
+    .forSpreadsheet(SpreadsheetApp.getActiveSpreadsheet())
+    .onEdit()
+    .create();
+
+  SpreadsheetApp.getUi().alert(
+    '✅ セットアップ完了\n\n' +
+    '出品DBの設定系シートを編集すると、\n' +
+    '出品シートに自動同期されます。'
+  );
+}

--- a/gas/ebay-db/bind/appsscript.json
+++ b/gas/ebay-db/bind/appsscript.json
@@ -1,0 +1,21 @@
+{
+  "timeZone": "Asia/Tokyo",
+  "dependencies": {
+    "libraries": [
+      {
+        "userSymbol": "EbayLib",
+        "libraryId": "LISTING_SA_SCRIPT_ID",
+        "version": "0",
+        "developmentMode": true
+      }
+    ]
+  },
+  "exceptionLogging": "STACKDRIVER",
+  "runtimeVersion": "V8",
+  "oauthScopes": [
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/script.scriptapp",
+    "https://www.googleapis.com/auth/script.container.ui"
+  ]
+}

--- a/gas/listing/container/Code.gs
+++ b/gas/listing/container/Code.gs
@@ -14,6 +14,12 @@
  * 8. メニュー「eBay出品管理」→「権限承認・トリガー登録」を実行
  */
 
+// onEdit 自動同期の対象シート（設定系シートのみ）
+const SYNC_TARGET_SHEETS_AUTO = [
+  'プルダウン管理', 'ツール設定', '状態_テンプレ',
+  'Description_テンプレ', '担当者管理', '報酬管理', 'ポリシー管理'
+];
+
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 // シート起動時メニュー
 // ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
@@ -445,10 +451,14 @@ function handleEdit(e) {
 
     // 出品シート以外の処理
     if (sheetName !== '出品') {
-      // 状態テンプレのプルダウン選択時
-      // ※ 状態テンプレシートは出品シートにバインドされているため
-      // 出品シートの状態テンプレ列の変更を検知
-      // → handleEdit内で出品シートの処理として対応済み
+      // 設定系シートの自動同期 (ss → db)
+      if (SYNC_TARGET_SHEETS_AUTO.indexOf(sheetName) !== -1) {
+        try {
+          EbayLib.autoSyncSheetToDB(e.source.getId(), sheetName);
+        } catch (syncErr) {
+          Logger.log('自動同期エラー（継続）: ' + syncErr.toString());
+        }
+      }
       return;
     }
 

--- a/gas/listing/standalone/SheetSync.gs
+++ b/gas/listing/standalone/SheetSync.gs
@@ -12,6 +12,7 @@ const SYNC_TARGET_SHEETS = [
   '状態_テンプレ',
   'Description_テンプレ',
   '担当者管理',
+  '報酬管理',
   'ポリシー管理',
   'HARU_CSV',
   'セルスタ_CSV'
@@ -132,6 +133,65 @@ function syncSheet(spreadsheetId, sheetName, direction) {
  */
 function getSyncTargetSheets() {
   return SYNC_TARGET_SHEETS;
+}
+
+/**
+ * 【自動同期】出品シート → 出品DB (ss_to_db)
+ * onEdit トリガーから呼び出す。エラーは呼び出し元でハンドリングすること。
+ *
+ * @param {string} sourceSpreadsheetId 出品スプレッドシートID
+ * @param {string} sheetName 同期するシート名
+ * @returns {{ success: boolean, message: string }}
+ */
+function autoSyncSheetToDB(sourceSpreadsheetId, sheetName) {
+  Logger.log('autoSyncSheetToDB: ' + sheetName);
+  return syncSheet(sourceSpreadsheetId, sheetName, 'ss_to_db');
+}
+
+/**
+ * 【自動同期】出品DB → 出品シート (db_to_ss)
+ * 出品DB側の onEdit トリガーから呼び出す。
+ *
+ * @param {string} dbSpreadsheetId 出品DBのスプレッドシートID
+ * @param {string} sheetName 同期するシート名
+ * @returns {{ success: boolean, message: string }}
+ */
+function autoSyncDBToSheet(dbSpreadsheetId, sheetName) {
+  Logger.log('autoSyncDBToSheet: ' + sheetName);
+  const listingSSId = getListingSheetIdFromDb_(dbSpreadsheetId);
+  if (!listingSSId) {
+    return { success: false, message: '出品DBのツール設定に「出品シート」が設定されていません。' };
+  }
+  return syncSheet(listingSSId, sheetName, 'db_to_ss');
+}
+
+/**
+ * 出品DBのツール設定から出品スプレッドシートIDを逆引きする
+ *
+ * @param {string} dbSpreadsheetId 出品DBのスプレッドシートID
+ * @returns {string|null} 出品スプレッドシートID（取得できない場合は null）
+ */
+function getListingSheetIdFromDb_(dbSpreadsheetId) {
+  try {
+    const dbSS = SpreadsheetApp.openById(dbSpreadsheetId);
+    const configSheet = dbSS.getSheetByName('ツール設定');
+    if (!configSheet) return null;
+
+    const lastRow = configSheet.getLastRow();
+    if (lastRow < 2) return null;
+
+    const data = configSheet.getRange(1, 1, lastRow, 2).getValues();
+    for (var i = 0; i < data.length; i++) {
+      if (String(data[i][0] || '').trim() === '出品シート') {
+        const urlOrId = String(data[i][1] || '').trim();
+        return urlOrId ? extractSpreadsheetId(urlOrId) : null;
+      }
+    }
+    return null;
+  } catch (e) {
+    Logger.log('getListingSheetIdFromDb_ エラー: ' + e.toString());
+    return null;
+  }
 }
 
 /**


### PR DESCRIPTION
## 概要

設定系シートの変更を出品DB ↔ 出品シート間で自動同期する機能を実装。

## Phase 1: 出品シート → 出品DB (ss→db)

- `gas/listing/standalone/SheetSync.gs`
  - `SYNC_TARGET_SHEETS` に '報酬管理' を追加
  - `autoSyncSheetToDB(sourceSpreadsheetId, sheetName)` を追加
  - `autoSyncDBToSheet(dbSpreadsheetId, sheetName)` を追加（Phase 2用）
  - `getListingSheetIdFromDb_(dbSpreadsheetId)` ヘルパーを追加（Phase 2用）
- `gas/listing/container/Code.gs`
  - `SYNC_TARGET_SHEETS_AUTO` 定数を追加（7シート）
  - `handleEdit()` の `sheetName !== '出品'` ブロックに自動同期呼び出しを追加

## Phase 2: 出品DB → 出品シート (db→ss)

- `gas/ebay-db/bind/` を新規作成（3ファイル）
  - `Code.gs`: `handleEditDB()` トリガー + `authorizeDBScript()` セットアップ
  - `appsscript.json`: EbayLib ライブラリ参照（`LISTING_SA_SCRIPT_ID` プレースホルダー）
  - `.clasp.json`: CI置換用プレースホルダー
- `.github/workflows/deploy-gas.yml`
  - paths に `gas/ebay-db/bind/**` を追加
  - `deploy-ebay-db-bind` ジョブを追加（graceful-skip パターン）

## 同期対象シート（7シート）

`プルダウン管理`, `ツール設定`, `状態_テンプレ`, `Description_テンプレ`, `担当者管理`, `報酬管理`, `ポリシー管理`

## セットアップ手順（Phase 2有効化）

1. GitHub Secrets に `EBAY_DB_BIND_DEV` / `EBAY_DB_BIND_PROD` を追加
2. 出品DBスプレッドシートに `gas/ebay-db/bind/Code.gs` を設置
3. 「⚙️ 出品DB」→「権限承認・トリガー登録」を実行

## Test plan

- [ ] 出品シートの「ツール設定」シートを編集 → 出品DBに同期されることを確認
- [ ] 出品DBの「ツール設定」シートを編集 → 出品シートに同期されることを確認
- [ ] Vero/禁止ワード・HARU_CSV は同期対象外であることを確認（onEditで発火しない）
- [ ] `handleEdit()` の既存動作（出品シートのステータス変更等）に影響がないことを確認
- [ ] deploy-gas.yml の新ジョブが graceful-skip（Secrets未設定時）で通過することを確認