### PR TITLE
fix: authorizeDBScript の getUi().alert() を Logger.log() に変更

### DIFF
--- a/gas/ebay-db/bind/Code.gs
+++ b/gas/ebay-db/bind/Code.gs
@@ -67,9 +67,5 @@ function authorizeDBScript() {
     .onEdit()
     .create();
 
-  SpreadsheetApp.getUi().alert(
-    '✅ セットアップ完了\n\n' +
-    '出品DBの設定系シートを編集すると、\n' +
-    '出品シートに自動同期されます。'
-  );
+  Logger.log('✅ handleEditDB トリガー登録完了');
 }


### PR DESCRIPTION
## Summary
- `authorizeDBScript()` の `SpreadsheetApp.getUi().alert()` を `Logger.log()` に変更
- スプレッドシートのコンテキストなしでも実行可能に（clasp run 対応）

## 変更内容
`gas/ebay-db/bind/Code.gs` の `authorizeDBScript()`:
- Before: `SpreadsheetApp.getUi().alert('✅ セットアップ完了...')`
- After: `Logger.log('✅ handleEditDB トリガー登録完了')`

## Test plan
- [ ] clasp run で `authorizeDBScript()` が正常実行されることを確認
- [ ] handleEditDB トリガーが登録されることを確認
- [ ] スプレッドシートのメニューから実行しても引き続き動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)