### PR TITLE
ci: deploy-ebay-db-bind に clasp run authorizeDBScript を追加

### DIFF
--- a/.github/workflows/deploy-gas.yml
+++ b/.github/workflows/deploy-gas.yml
@@ -202,6 +202,15 @@ jobs:
           sed -i "s/LISTING_SA_SCRIPT_ID/$SA_SCRIPT_ID/" appsscript.json
           clasp push --force
 
+      - name: Run authorizeDBScript to register handleEditDB trigger
+        if: github.ref_name == 'develop'
+        continue-on-error: true
+        run: |
+          cd gas/ebay-db/bind
+          SCRIPT_ID="${{ secrets.EBAY_DB_BIND_DEV }}"
+          sed -i "s/REPLACED_BY_CI/$SCRIPT_ID/" .clasp.json
+          clasp run authorizeDBScript
+
   deploy-ebay-db-container:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/develop'


### PR DESCRIPTION
## Summary
- `deploy-ebay-db-bind` job に `clasp run authorizeDBScript` ステップを追加
- develop ブランチへのデプロイ時に handleEditDB トリガーを自動登録
- `continue-on-error: true` で失敗してもデプロイは継続

## 変更内容
`.github/workflows/deploy-gas.yml`:
- `deploy-ebay-db-bind` job に新ステップ追加（develop のみ実行）
- CI credentials (CLASPRC_JSON) で `clasp run authorizeDBScript` を実行

## Test plan
- [ ] CI で `clasp run authorizeDBScript` が正常実行されることを確認
- [ ] handleEditDB トリガーが登録されることを確認（Apps Script トリガー一覧で確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)