### PR TITLE
fix: bind/appsscript.json に executionApi 追加（clasp run 対応）

### DIFF
--- a/gas/ebay-db/bind/appsscript.json
+++ b/gas/ebay-db/bind/appsscript.json
@@ -10,6 +10,9 @@
       }
     ]
   },
+  "executionApi": {
+    "access": "ANYONE"
+  },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "oauthScopes": [


### PR DESCRIPTION
## Summary
- `gas/ebay-db/bind/appsscript.json` に `executionApi.access: "ANYONE"` を追加
- container スクリプトと同様の設定により `clasp run authorizeDBScript` が実行可能になる

## 変更内容
```json
"executionApi": {
  "access": "ANYONE"
}
```

## なぜこれが必要か
`clasp run` は Apps Script Execution API を使用する。
`executionApi` の設定がないと "Script function not found" エラーになる（container は既に設定済み）。

## Test plan
- [ ] CI `deploy-ebay-db-bind` job で `clasp run authorizeDBScript` が成功することを確認
- [ ] Apps Script のトリガー一覧で `handleEditDB` が登録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)