### PR TITLE
fix: appsscript.json から script.container.ui スコープを削除

### DIFF
--- a/gas/ebay-db/bind/appsscript.json
+++ b/gas/ebay-db/bind/appsscript.json
@@ -18,7 +18,6 @@
   "oauthScopes": [
     "https://www.googleapis.com/auth/spreadsheets",
     "https://www.googleapis.com/auth/drive",
-    "https://www.googleapis.com/auth/script.scriptapp",
-    "https://www.googleapis.com/auth/script.container.ui"
+    "https://www.googleapis.com/auth/script.scriptapp"
   ]
 }


### PR DESCRIPTION
## Summary
- `script.container.ui` スコープを oauthScopes から削除
- `onOpen()` の simple trigger は UI アクセスを暗黙的に持つため宣言不要
- このスコープが Execution API の実行権限をブロックしていた可能性

## Test plan
- [ ] CI `clasp run authorizeDBScript` が成功することを確認
- [ ] Apps Script から `onOpen()` のメニューが引き続き表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)