### PR TITLE
diag: testClaspRun() 追加（clasp run 権限確認）

### DIFF
--- a/.github/workflows/deploy-gas.yml
+++ b/.github/workflows/deploy-gas.yml
@@ -202,13 +202,16 @@ jobs:
           sed -i "s/LISTING_SA_SCRIPT_ID/$SA_SCRIPT_ID/" appsscript.json
           clasp push --force
 
-      - name: Run authorizeDBScript to register handleEditDB trigger
+      - name: Test clasp run (diagnostic)
         if: github.ref_name == 'develop'
         continue-on-error: true
         run: |
           cd gas/ebay-db/bind
           SCRIPT_ID="${{ secrets.EBAY_DB_BIND_DEV }}"
           sed -i "s/REPLACED_BY_CI/$SCRIPT_ID/" .clasp.json
+          echo "--- testClaspRun ---"
+          clasp run testClaspRun
+          echo "--- authorizeDBScript ---"
           clasp run authorizeDBScript
 
   deploy-ebay-db-container:

--- a/gas/ebay-db/bind/Code.gs
+++ b/gas/ebay-db/bind/Code.gs
@@ -51,6 +51,14 @@ function handleEditDB(e) {
 }
 
 /**
+ * 診断用: clasp run で実行可能か確認する
+ */
+function testClaspRun() {
+  Logger.log('✅ clasp run 動作確認: scriptId=' + ScriptApp.getScriptId());
+  return 'ok';
+}
+
+/**
  * 権限承認 & installable onEdit トリガー登録
  * 初回セットアップ時に手動で実行する
  */


### PR DESCRIPTION
診断用関数を追加。CI で testClaspRun → authorizeDBScript の順に実行して権限エラーの原因を特定する。