### PR TITLE
feat: container scriptからhandleEditDBトリガーを自動登録

### DIFF
--- a/.github/workflows/deploy-gas.yml
+++ b/.github/workflows/deploy-gas.yml
@@ -236,8 +236,15 @@ jobs:
         run: |
           cd gas/ebay-db/container
           SCRIPT_ID="${{ secrets.EBAY_DB_CB_DEV }}"
+          SA_SCRIPT_ID="${{ secrets.LISTING_SA_DEV }}"
           sed -i "s/REPLACED_BY_CI/$SCRIPT_ID/" .clasp.json
+          sed -i "s/LISTING_SA_SCRIPT_ID/$SA_SCRIPT_ID/" appsscript.json
           clasp push --force
+
+      - name: Register handleEditDB trigger on eBay出品DB
+        run: |
+          cd gas/ebay-db/container
+          clasp run registerHandleEditTrigger
 
       - name: Import condition_ja_map and sync to reference book
         run: |

--- a/gas/ebay-db/container/RegisterTrigger.gs
+++ b/gas/ebay-db/container/RegisterTrigger.gs
@@ -1,0 +1,62 @@
+/**
+ * RegisterTrigger.gs - eBay出品DB onEdit トリガー登録
+ *
+ * container script (standalone) から clasp run で実行可能。
+ * CI フロー: clasp push → clasp run registerHandleEditTrigger
+ *
+ * 目的: eBay出品DB スプレッドシートの installable onEdit トリガーを
+ *       このスクリプトプロジェクトに登録する。
+ *       bind スクリプトは container-bound のため Execution API から実行不可であり、
+ *       同等の handleEditDB をこの standalone スクリプトに配置して CI から自動登録する。
+ */
+
+var DB_SPREADSHEET_ID = '1gGoJSu-ckMllYWuFCoERGVIPBDGvpVVRHDStx58MEgQ';
+
+var SYNC_TARGET_SHEETS_DB = [
+  'プルダウン管理', 'ツール設定', '状態_テンプレ',
+  'Description_テンプレ', '担当者管理', '報酬管理', 'ポリシー管理'
+];
+
+/**
+ * eBay出品DB の installable onEdit トリガーを登録
+ * 既存の handleEditDB トリガーを削除してから再登録（重複防止）
+ *
+ * 実行方法: clasp run registerHandleEditTrigger
+ */
+function registerHandleEditTrigger() {
+  ScriptApp.getProjectTriggers().forEach(function(t) {
+    if (t.getHandlerFunction() === 'handleEditDB') {
+      ScriptApp.deleteTrigger(t);
+    }
+  });
+
+  var ss = SpreadsheetApp.openById(DB_SPREADSHEET_ID);
+
+  ScriptApp.newTrigger('handleEditDB')
+    .forSpreadsheet(ss)
+    .onEdit()
+    .create();
+
+  Logger.log('✅ handleEditDB トリガー登録完了 (spreadsheetId=' + DB_SPREADSHEET_ID + ')');
+}
+
+/**
+ * eBay出品DB の onEdit ハンドラー
+ * 設定系シートの変更を検知して出品シートに自動同期 (db → ss)
+ *
+ * @param {GoogleAppsScript.Events.SheetsOnEdit} e
+ */
+function handleEditDB(e) {
+  if (!e || !e.range) return;
+  var sheetName = e.range.getSheet().getName();
+  if (SYNC_TARGET_SHEETS_DB.indexOf(sheetName) === -1) return;
+
+  try {
+    var result = EbayLib.autoSyncDBToSheet(e.source.getId(), sheetName);
+    if (result && !result.success) {
+      Logger.log('⚠️ 自動同期スキップ（' + sheetName + '）: ' + result.message);
+    }
+  } catch (err) {
+    Logger.log('handleEditDB エラー（継続）: ' + err.toString());
+  }
+}

--- a/gas/ebay-db/container/appsscript.json
+++ b/gas/ebay-db/container/appsscript.json
@@ -1,6 +1,15 @@
 {
   "timeZone": "Asia/Tokyo",
-  "dependencies": {},
+  "dependencies": {
+    "libraries": [
+      {
+        "userSymbol": "EbayLib",
+        "libraryId": "LISTING_SA_SCRIPT_ID",
+        "version": "0",
+        "developmentMode": true
+      }
+    ]
+  },
   "exceptionLogging": "STACKDRIVER",
   "runtimeVersion": "V8",
   "executionApi": {


### PR DESCRIPTION
## 概要

bind スクリプト（container-bound）は Apps Script Execution API の制限により `clasp run` での実行が不可。
container スクリプト（standalone）に `handleEditDB` と `registerHandleEditTrigger` を追加し、CI から自動登録できるようにする。

## 変更内容

- `gas/ebay-db/container/RegisterTrigger.gs` 新規追加
  - `registerHandleEditTrigger()`: eBay出品DB スプレッドシート (`1gGoJSu-...MEgQ`) に installable onEdit トリガーを登録
  - `handleEditDB()`: bind スクリプトと同等のロジック（EbayLib.autoSyncDBToSheet 呼び出し）
- `gas/ebay-db/container/appsscript.json`: EbayLib ライブラリ依存を追加（`LISTING_SA_SCRIPT_ID` プレースホルダー）
- `.github/workflows/deploy-gas.yml`: `deploy-ebay-db-container` ジョブに以下を追加
  - `LISTING_SA_SCRIPT_ID` → `LISTING_SA_DEV` シークレットへの sed 置換
  - `clasp run registerHandleEditTrigger` ステップ

## CI フロー

```
clasp push → clasp run registerHandleEditTrigger → clasp run importConditionJaMap
```

## 確認方法

develop マージ後 CI ログで `✅ handleEditDB トリガー登録完了` が出力されることを確認