### PR TITLE
fix: registerHandleEditTriggerのCI例外検知を追加

### DIFF
--- a/.github/workflows/deploy-gas.yml
+++ b/.github/workflows/deploy-gas.yml
@@ -244,7 +244,13 @@ jobs:
       - name: Register handleEditDB trigger on eBay出品DB
         run: |
           cd gas/ebay-db/container
-          clasp run registerHandleEditTrigger
+          OUTPUT=$(clasp run registerHandleEditTrigger 2>&1)
+          echo "$OUTPUT"
+          if echo "$OUTPUT" | grep -q "Exception"; then
+            echo "❌ registerHandleEditTrigger failed. Authorize script.scriptapp scope in GAS editor first."
+            exit 1
+          fi
+          echo "✅ registerHandleEditTrigger succeeded"
 
       - name: Import condition_ja_map and sync to reference book
         run: |


### PR DESCRIPTION
## 概要

`clasp run` はスクリプト内で例外が発生しても exit 0 を返すため、CI が成功と誤判定していた。
output に "Exception" が含まれる場合は exit 1 で明示的に失敗扱いにする。

## 変更内容

- `deploy-ebay-db-container` の `Register handleEditDB trigger` ステップで出力を検査
- `Exception` 検出時は `exit 1` で CI 失敗扱い

## 次のアクション（ユーザー作業が必要）

`script.scriptapp` スコープの承認が必要:
1. GitHub Secrets の `EBAY_DB_CB_DEV` でコンテナスクリプト ID を確認
2. `https://script.google.com/d/{EBAY_DB_CB_DEV}/edit` を開く
3. `registerHandleEditTrigger` を手動実行 → 権限承認ダイアログで「許可」
4. 承認後に develop へ再 push すれば CI が正常完了する予定