### PR TITLE
fix: registerHandleEditTriggerにcontinue-on-errorを付与

### DIFF
--- a/.github/workflows/deploy-gas.yml
+++ b/.github/workflows/deploy-gas.yml
@@ -242,6 +242,7 @@ jobs:
           clasp push --force
 
       - name: Register handleEditDB trigger on eBay出品DB
+        continue-on-error: true
         run: |
           cd gas/ebay-db/container
           OUTPUT=$(clasp run registerHandleEditTrigger 2>&1)


### PR DESCRIPTION
script.scriptapp スコープ未承認のため CI が失敗する暫定対処。GAS エディタで一度承認すれば不要になる。